### PR TITLE
Add Appx signing and CI for Windows navigation tests

### DIFF
--- a/.github/workflows/windows_navigation_tests.yml
+++ b/.github/workflows/windows_navigation_tests.yml
@@ -1,0 +1,65 @@
+name: Build and Run Windows Navigation Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  software_navigation_tests:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-prerelease: true
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '8.0.x'
+     
+      - name: Install MAUI workloads
+        run: |
+          dotnet workload install maui
+
+      - name: Install Appium and Drivers
+        run: |
+          npm install -g appium --unsafe-perm=true --allow-root
+          appium driver install --source=npm appium-windows-driver
+
+      - name: Start Appium Server
+        run: |
+          nohup appium --log appium.log &
+
+      - name: Restore MAUI App for Android
+        run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
+
+      - name: Build Code
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-android -c Release --no-restore
+
+      - name: Decrypt PFX File
+        run: |
+          echo "${{ secrets.WINDOWSSIGNINGCERT }}" > cert.pfx.asc
+          certutil -decode cert.pfx.asc cert.pfx
+
+      - name: Add Cert to Store
+        run: certutil -user -q -p ${{ secrets.WINDOWSSIGNINGCERTPWD }} -importpfx cert.pfx NoRoot
+
+      - name: Publish App
+        run: |
+         dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net8.0-windows10.0.19041.0 /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="${{ secrets.WINDOWSSIGNINGCERTTHUMBPRINT }}"      
+      
+      - name: Install App
+        shell: powershell
+        run: |         
+         Import-Module Appx 
+         .\TransactionMobile.Maui/bin/Release/net8.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile.Maui_1.0.0.0_Test/Install.ps1 -Force
+
+      - name: Run Windows Navigation Tests
+        run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRNavTest)&(Category=Windows)" --no-restore
+
+  

--- a/TransactionMobile.Maui/TransactionMobile.Maui.csproj
+++ b/TransactionMobile.Maui/TransactionMobile.Maui.csproj
@@ -38,6 +38,8 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+		<PackageCertificateThumbprint>376AD93CB29454751B808E6883ED14E377D979F2</PackageCertificateThumbprint>
+		<AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Added package certificate thumbprint and enabled Appx package signing in `TransactionMobile.Maui.csproj`.
- Created `windows_navigation_tests.yml` for automating the build and test process for Windows navigation tests.