### PR TITLE
Add Windows E2E Tests workflow to GitHub Actions

### DIFF
--- a/.github/workflows/windows_e2e_tests.yml
+++ b/.github/workflows/windows_e2e_tests.yml
@@ -1,0 +1,70 @@
+name: Build and Run Windows End to End Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  end_to_end_tests:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build Windows SQL Server
+        run: |
+           cd SQLDocker
+           docker build -t mssqlserver:2022-ltsc2022 --build-arg SQL_VERSION=2022 --build-arg WIN_VERSION=ltsc2022 .
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-prerelease: true
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '8.0.x'
+     
+      - name: Install MAUI workloads
+        run: |
+          dotnet workload install maui
+
+      - name: Install Appium and Drivers
+        run: |
+          npm install -g appium --unsafe-perm=true --allow-root
+          appium driver install --source=npm appium-windows-driver
+
+      - name: Start Appium Server
+        run: |
+          nohup appium --log appium.log &
+
+      - name: Restore MAUI App for Android
+        run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
+
+      - name: Build Code
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-android -c Release --no-restore
+
+      - name: Decrypt PFX File
+        run: |
+          echo "${{ secrets.WINDOWSSIGNINGCERT }}" > cert.pfx.asc
+          certutil -decode cert.pfx.asc cert.pfx
+
+      - name: Add Cert to Store
+        run: certutil -user -q -p ${{ secrets.WINDOWSSIGNINGCERTPWD }} -importpfx cert.pfx NoRoot
+
+      - name: Publish App
+        run: |
+         dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net8.0-windows10.0.19041.0 /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="${{ secrets.WINDOWSSIGNINGCERTTHUMBPRINT }}"      
+      
+      - name: Install App
+        shell: powershell
+        run: |         
+         Import-Module Appx 
+         .\TransactionMobile.Maui/bin/Release/net8.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile.Maui_1.0.0.0_Test/Install.ps1 -Force
+
+      - name: Run Windows Navigation Tests
+        run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRTest)&(Category=Windows)" --no-restore
+
+  


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow named "Build and Run Windows End to End Tests." It is triggered on pull requests to the `main` branch and automates the process of building, testing, and publishing a .NET MAUI application in a Windows environment. The workflow includes steps for checking out the repository, building a Windows SQL Server Docker image, setting up MSBuild and .NET, installing MAUI workloads, installing Appium and its drivers, starting the Appium server, restoring the MAUI app for Android, building the code, decrypting a PFX file, adding the certificate to the store, publishing the app, installing the app, and running Windows navigation tests.