### PR TITLE
Add iOS Navigation Tests workflow to GitHub Actions

### DIFF
--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -48,32 +48,35 @@ jobs:
 
       - name: Build WebDriverAgent for Simulator
         run: |
+          set -e
           export UDID=$UDID
+          echo "Target Simulator UDID: $UDID"
+
+          # Navigate into WebDriverAgent
           cd WebDriverAgent
           mkdir -p build
+
+          echo "Building WebDriverAgentRunner with code signing for simulator..."
           xcodebuild -scheme WebDriverAgentRunner \
             -destination "id=$UDID" \
             -derivedDataPath build \
             -configuration Debug \
-            build-for-testing | xcpretty      
+            -allowProvisioningUpdates \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build-for-testing | xcpretty
 
-      - name: Debug List Built App Contents
-        run: ls -R WebDriverAgent/build/Build/Products/Debug-iphonesimulator
-
-      - name: 🔍 Find WDA binary and check architecture
-        run: |
-          echo "Searching for WebDriverAgentRunner binary..."
-          WDA_BINARY=$(find WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app -type f -name WebDriverAgentRunner)
-
-          if [ -z "$WDA_BINARY" ]; then
-            echo "❌ WebDriverAgentRunner binary not found!"
+          echo "Checking built app architecture..."
+          APP_PATH="build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app/WebDriverAgentRunner"
+          
+          if [ -f "$APP_PATH" ]; then
+            lipo -info "$APP_PATH"
+          else
+            echo "::error::WebDriverAgentRunner binary not found at expected path: $APP_PATH"
             exit 1
           fi
-
-          echo "✅ Found binary at: $WDA_BINARY"
-          echo "📦 Architecture info:"
-          lipo -info "$WDA_BINARY"
-
+      
       - name: Debug WebDriverAgent App Install and Bundle ID
         run: |
           echo "Checking WebDriverAgentRunner app..."

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -41,7 +41,7 @@ jobs:
           git clone https://github.com/appium/appium-xcuitest-driver.git
           cd appium-xcuitest-driver
           npm install
-          npx appium driver install --source=local driver $(pwd)
+          npx appium driver install --source=local ./
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -40,11 +40,6 @@ jobs:
           xcrun simctl bootstatus "$UDID" -b
           echo "UDID=$UDID" >> $GITHUB_ENV
 
-      - name: Install MAUI Workloads
-        run: |
-          dotnet workload install ios --ignore-failed-sources
-          dotnet workload install maui --ignore-failed-sources
-
       #- name: Install Appium and Drivers
       #  run: |
       #    npm install -g appium --unsafe-perm=true --allow-root
@@ -65,6 +60,11 @@ jobs:
       - name: Start Appium Server
         run: |
           nohup appium --log appium.log &
+
+      - name: Install MAUI Workloads
+        run: |
+          dotnet workload install ios --ignore-failed-sources
+          dotnet workload install maui --ignore-failed-sources
 
       - name: Restore MAUI App for iOS
         run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -41,7 +41,7 @@ jobs:
           git clone https://github.com/appium/appium-xcuitest-driver.git
           cd appium-xcuitest-driver
           npm install
-          npx appium driver install --source=local ./
+          npx appium driver update --source=local ./
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Appium and Drivers
         run: |
           npm install -g appium --unsafe-perm=true --allow-root
-          appium driver install xcuitest@5.14.1 
+          appium driver install xcuitest@next
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '16.14.2'
+          node-version: '18'
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -41,7 +41,7 @@ jobs:
           git clone https://github.com/appium/appium-xcuitest-driver.git
           cd appium-xcuitest-driver
           npm install
-          npx appium driver install --source=local .
+          npx appium driver update --source=local .
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -55,7 +55,23 @@ jobs:
       - name: Install Appium XCUITest Driver from GitHub
         run: |
           npm install -g appium --unsafe-perm=true --allow-root
-          appium driver install --source=git --package=appium-xcuitest-driver https://github.com/appium/appium-xcuitest-driver.git
+          #appium driver install --source=git --package=appium-xcuitest-driver https://github.com/appium/appium-xcuitest-driver.git
+
+      - name: Install Appium XCUITest Driver (Pinned Commit)
+        run: |
+          git clone https://github.com/appium/appium-xcuitest-driver.git
+          cd appium-xcuitest-driver
+          git checkout 0a67193f276d55e2b5e76b20f75b3e8d85e04714  # Known working commit
+          npm install
+          mkdir -p ~/.appium/node_modules/
+          cp -R . ~/.appium/node_modules/appium-xcuitest-driver          
+
+      - name: Prebuild WebDriverAgent
+        run: |
+          xcodebuild -project ~/.appium/node_modules/appium-xcuitest-driver/WebDriverAgent/WebDriverAgent.xcodeproj \
+            -scheme WebDriverAgentRunner \
+            -destination "platform=iOS Simulator,id=$UDID" \
+            build-for-testing
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -34,10 +34,7 @@ jobs:
 
       - name: Boot iPhone 15 Pro (iOS 17.2) Simulator
         run: |
-          UDID=$(xcrun simctl list devices available | \
-            grep -i "iPhone 15 Pro (17.2" | \
-            grep -oE '([0-9A-F-]{36})' | head -n 1)
-
+          UDID=$(xcrun simctl list devices available | grep -i "iPhone 15 Pro" | grep -i "17.2" | awk -F'[()]' '{print $2}' | head -n 1)
           if [ -z "$UDID" ]; then
             echo "::error::No matching iPhone 15 Pro (iOS 17.2) simulator found!"
             exit 1

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -65,18 +65,20 @@ jobs:
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            build-for-testing | xcpretty
-
-          echo "Checking built app architecture..."
-          APP_PATH="build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app/WebDriverAgentRunner"
-          
-          if [ -f "$APP_PATH" ]; then
-            lipo -info "$APP_PATH"
-          else
-            echo "::error::WebDriverAgentRunner binary not found at expected path: $APP_PATH"
+            build-for-testing | xcpretty         
+      
+      - name: 🔍 Find WDA binary and check architecture
+        run: |
+          echo "Searching for WebDriverAgentRunner binary..."
+          WDA_BINARY=$(find WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app -type f -name WebDriverAgentRunner)
+          if [ -z "$WDA_BINARY" ]; then
+            echo "❌ WebDriverAgentRunner binary not found!"
             exit 1
           fi
-      
+          echo "✅ Found binary at: $WDA_BINARY"
+          echo "📦 Architecture info:"
+          lipo -info "$WDA_BINARY"
+
       - name: Debug WebDriverAgent App Install and Bundle ID
         run: |
           echo "Checking WebDriverAgentRunner app..."

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -40,11 +40,6 @@ jobs:
           xcrun simctl bootstatus "$UDID" -b
           echo "UDID=$UDID" >> $GITHUB_ENV
 
-      - name: Install Appium XCUITest Driver from GitHub
-        run: |
-          npm install -g appium --unsafe-perm=true --allow-root
-          appium driver install --source=git --package=appium-xcuitest-driver https://github.com/appium/appium-xcuitest-driver.git
-
       - name: Clone WebDriverAgent
         run: |
           git clone https://github.com/appium/WebDriverAgent.git
@@ -65,20 +60,11 @@ jobs:
       - name: Debug List Built App Contents
         run: ls -R WebDriverAgent/build/Build/Products/Debug-iphonesimulator
 
-      #- name: Install and Launch WebDriverAgentRunner on Simulator
-      #  run: |
-      #    echo "Installing WDA to Simulator with UDID=$UDID"
-      #    APP_PATH="WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app"
-      #    
-      #    # Just in case: boot again (won't hurt)
-      #    xcrun simctl boot "$UDID" || true
-      #    xcrun simctl bootstatus "$UDID" -b#
-
-#          # Install the app
- #         xcrun simctl install "$UDID" "$APP_PATH"
-  #        
-   #       # Launch the app
-    #      xcrun simctl launch "$UDID" com.facebook.WebDriverAgentRunner || echo "WDA launch attempted"
+      - name: Check WDA architecture
+        run: |
+          WDA_APP_PATH=$(find WDA -name "WebDriverAgentRunner-Runner.app" | head -n 1)
+          echo "Checking architecture of $WDA_APP_PATH"
+          lipo -info "$WDA_APP_PATH/WebDriverAgentRunner"
 
       - name: Debug WebDriverAgent App Install and Bundle ID
         run: |
@@ -101,6 +87,10 @@ jobs:
           echo "Launching WebDriverAgent..."
           xcrun simctl launch "$UDID" "$BUNDLE_ID"
 
+      - name: Install Appium XCUITest Driver from GitHub
+        run: |
+          npm install -g appium --unsafe-perm=true --allow-root
+          appium driver install --source=git --package=appium-xcuitest-driver https://github.com/appium/appium-xcuitest-driver.git
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -62,9 +62,7 @@ jobs:
 
       - name: Check WDA architecture
         run: |
-          WDA_APP_PATH=$(find WDA -name "WebDriverAgentRunner-Runner.app" | head -n 1)
-          echo "Checking architecture of $WDA_APP_PATH"
-          lipo -info "$WDA_APP_PATH/WebDriverAgentRunner"
+          lipo -info WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app/WebDriverAgentRunner
 
       - name: Debug WebDriverAgent App Install and Bundle ID
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -45,17 +45,22 @@ jobs:
           dotnet workload install ios --ignore-failed-sources
           dotnet workload install maui --ignore-failed-sources
 
-      - name: Install Appium and Drivers
-        run: |
-          npm install -g appium --unsafe-perm=true --allow-root
+      #- name: Install Appium and Drivers
+      #  run: |
+      #    npm install -g appium --unsafe-perm=true --allow-root
+
+      #- name: Install Appium XCUITest Driver from GitHub
+      #  run: |
+      #    git clone https://github.com/appium/appium-xcuitest-driver.git
+      #    cd appium-xcuitest-driver
+      #    npm install
+      #    mkdir -p ~/.appium/node_modules/
+      #    cp -R . ~/.appium/node_modules/appium-xcuitest-driver
 
       - name: Install Appium XCUITest Driver from GitHub
         run: |
-          git clone https://github.com/appium/appium-xcuitest-driver.git
-          cd appium-xcuitest-driver
-          npm install
-          mkdir -p ~/.appium/node_modules/
-          cp -R . ~/.appium/node_modules/appium-xcuitest-driver
+          npm install -g appium --unsafe-perm=true --allow-root
+          appium driver install --source=git https://github.com/appium/appium-xcuitest-driver.git
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -41,7 +41,7 @@ jobs:
           git clone https://github.com/appium/appium-xcuitest-driver.git
           cd appium-xcuitest-driver
           npm install
-          npx appium driver install --source=local
+          npx appium driver install --source=local driver $(pwd)
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -60,9 +60,19 @@ jobs:
       - name: Debug List Built App Contents
         run: ls -R WebDriverAgent/build/Build/Products/Debug-iphonesimulator
 
-      - name: Check WDA architecture
+      - name: 🔍 Find WDA binary and check architecture
         run: |
-          lipo -info WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app/WebDriverAgentRunner
+          echo "Searching for WebDriverAgentRunner binary..."
+          WDA_BINARY=$(find WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app -type f -name WebDriverAgentRunner)
+
+          if [ -z "$WDA_BINARY" ]; then
+            echo "❌ WebDriverAgentRunner binary not found!"
+            exit 1
+          fi
+
+          echo "✅ Found binary at: $WDA_BINARY"
+          echo "📦 Architecture info:"
+          lipo -info "$WDA_BINARY"
 
       - name: Debug WebDriverAgent App Install and Bundle ID
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: 🔍 List Available Simulators
+        run: |
+          echo "Available iOS Simulators:"
+          xcrun simctl list devices available
+
       - name: Boot iOS Simulator 17.2
         run: |
           export UDID=$(xcrun simctl list devices available | grep -i "iPhone 15 Pro (17.2)" | grep -oE '([0-9A-F-]{36})' | head -n 1)

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -27,11 +27,12 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Boot Existing iOS Simulator
+      - name: Boot iOS Simulator 17.2
         run: |
-          export UDID=$(xcrun simctl list devices available | grep "iPhone" | grep -oE '([0-9A-F-]{36})' | head -n 1)
+          export UDID=$(xcrun simctl list devices available | grep -i "iPhone 15 Pro (17.2)" | grep -oE '([0-9A-F-]{36})' | head -n 1)
           echo "Booting Simulator UDID: $UDID"
           xcrun simctl boot "$UDID"
+          echo "UDID=$UDID" >> $GITHUB_ENV
 
       - name: Wait for iOS Simulator to Boot
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -56,7 +56,8 @@ jobs:
           cd WebDriverAgent
           mkdir -p build
 
-          echo "Building WebDriverAgentRunner with code signing for simulator..."
+          echo "Building WebDriverAgentRunner with manual signing disabled..."
+
           xcodebuild -scheme WebDriverAgentRunner \
             -destination "id=$UDID" \
             -derivedDataPath build \
@@ -65,20 +66,10 @@ jobs:
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            build-for-testing | xcpretty         
-      
-      - name: 🔍 Find WDA binary and check architecture
-        run: |
-          echo "Searching for WebDriverAgentRunner binary..."
-          WDA_BINARY=$(find WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app -type f -name WebDriverAgentRunner)
-          if [ -z "$WDA_BINARY" ]; then
-            echo "❌ WebDriverAgentRunner binary not found!"
-            exit 1
-          fi
-          echo "✅ Found binary at: $WDA_BINARY"
-          echo "📦 Architecture info:"
-          lipo -info "$WDA_BINARY"
-
+            DEVELOPMENT_TEAM="" \
+            PRODUCT_BUNDLE_IDENTIFIER=com.appium.WebDriverAgentRunner \
+            build-for-testing | xcpretty
+                
       - name: Debug WebDriverAgent App Install and Bundle ID
         run: |
           echo "Checking WebDriverAgentRunner app..."

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -40,36 +40,38 @@ jobs:
           xcrun simctl bootstatus "$UDID" -b
           echo "UDID=$UDID" >> $GITHUB_ENV
 
-      #- name: Install Appium and Drivers
-      #  run: |
-      #    npm install -g appium --unsafe-perm=true --allow-root
-
-      #- name: Install Appium XCUITest Driver from GitHub
-      #  run: |
-      #    git clone https://github.com/appium/appium-xcuitest-driver.git
-      #    cd appium-xcuitest-driver
-      #    npm install
-      #    mkdir -p ~/.appium/node_modules/
-      #    cp -R . ~/.appium/node_modules/appium-xcuitest-driver
-
       - name: Install Appium XCUITest Driver from GitHub
         run: |
           npm install -g appium --unsafe-perm=true --allow-root
           appium driver install --source=git --package=appium-xcuitest-driver https://github.com/appium/appium-xcuitest-driver.git
 
-      - name: Download Prebuilt WebDriverAgent
+      - name: Clone WebDriverAgent
         run: |
-          curl -L -o WebDriverAgent.zip https://github.com/appium/WebDriverAgent/releases/download/v9.4.1/WebDriverAgentRunner-Runner.zip
-          unzip WebDriverAgent.zip -d WebDriverAgent
+          git clone https://github.com/appium/WebDriverAgent.git
+          cd WebDriverAgent
+          git checkout v9.4.1
 
-      - name: Set WebDriverAgent Environment Variable
-        run: echo "WDA_PATH=$(pwd)/WebDriverAgent" >> $GITHUB_ENV
-
-      - name: Install Prebuilt WebDriverAgent onto Simulator
+      - name: Build WebDriverAgent for Simulator
         run: |
-          xcrun simctl install "$UDID" WebDriverAgent/WebDriverAgentRunner-Runner.app
-          xcrun simctl launch "$UDID" com.facebook.WebDriverAgentRunner
+          export UDID=$UDID
+          cd WebDriverAgent
+          mkdir -p build
+          xcodebuild -scheme WebDriverAgentRunner \
+            -destination "id=$UDID" \
+            -derivedDataPath build \
+            -configuration Debug \
+            build-for-testing | xcpretty      
 
+      - name: Install and Launch WebDriverAgentRunner on Simulator
+        run: |
+          export UDID=$UDID
+          APP_PATH="WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app"
+          
+          xcrun simctl install "$UDID" "$APP_PATH"
+          xcrun simctl launch "$UDID" com.facebook.WebDriverAgentRunner || echo "WDA launch attempted"
+
+          # Optional: Check logs if debugging
+          xcrun simctl spawn "$UDID" log stream --predicate 'process == "WebDriverAgentRunner"' --style compact --timeout 10
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -62,7 +62,7 @@ jobs:
             -configuration Debug \
             build-for-testing | xcpretty      
 
-      - name: Debug: List Built App Contents
+      - name: Debug List Built App Contents
         run: ls -R WebDriverAgent/build/Build/Products/Debug-iphonesimulator
 
       - name: Install and Launch WebDriverAgentRunner on Simulator

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -65,6 +65,12 @@ jobs:
       - name: Set WebDriverAgent Environment Variable
         run: echo "WDA_PATH=$(pwd)/WebDriverAgent" >> $GITHUB_ENV
 
+      - name: Install Prebuilt WebDriverAgent onto Simulator
+        run: |
+          xcrun simctl install "$UDID" WebDriverAgent/WebDriverAgentRunner-Runner.app
+          xcrun simctl launch "$UDID" com.facebook.WebDriverAgentRunner
+
+
       - name: Start Appium Server
         run: |
           nohup appium --log appium.log &

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Appium XCUITest Driver from GitHub
         run: |
           npm install -g appium --unsafe-perm=true --allow-root
-          appium driver install --source=git https://github.com/appium/appium-xcuitest-driver.git
+          appium driver install --source=git --package=appium-xcuitest-driver https://github.com/appium/appium-xcuitest-driver.git
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -66,12 +66,6 @@ jobs:
       - name: Run iOS Navigation Tests
         run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
 
-      - name: 🧼 Shutdown simulator
-        if: always()
-        run: |
-          xcrun simctl shutdown "$SIMULATOR_NAME"
-          xcrun simctl delete "$SIMULATOR_NAME"
-
       - name: Upload Appium Logs on Failure      
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -55,22 +55,15 @@ jobs:
       - name: Install Appium XCUITest Driver from GitHub
         run: |
           npm install -g appium --unsafe-perm=true --allow-root
-          #appium driver install --source=git --package=appium-xcuitest-driver https://github.com/appium/appium-xcuitest-driver.git
+          appium driver install --source=git --package=appium-xcuitest-driver https://github.com/appium/appium-xcuitest-driver.git
 
-      - name: Install Appium XCUITest Driver (Pinned Commit)
+      - name: Download Prebuilt WebDriverAgent
         run: |
-          git clone https://github.com/appium/appium-xcuitest-driver.git
-          cd appium-xcuitest-driver
-          npm install
-          mkdir -p ~/.appium/node_modules/
-          cp -R . ~/.appium/node_modules/appium-xcuitest-driver          
+          curl -L -o WebDriverAgent.zip https://github.com/appium/WebDriverAgent/releases/download/v9.4.1/WebDriverAgentRunner-Runner.zip
+          unzip WebDriverAgent.zip -d WebDriverAgent
 
-      - name: Prebuild WebDriverAgent
-        run: |
-          xcodebuild -project ~/.appium/node_modules/appium-xcuitest-driver/WebDriverAgent/WebDriverAgent.xcodeproj \
-            -scheme WebDriverAgentRunner \
-            -destination "platform=iOS Simulator,id=$UDID" \
-            build-for-testing
+      - name: Set WebDriverAgent Environment Variable
+        run: echo "WDA_PATH=$(pwd)/WebDriverAgent" >> $GITHUB_ENV
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -85,7 +85,7 @@ jobs:
           echo "Checking WebDriverAgentRunner app..."
 
           echo "Simulator UDID: $UDID"
-          APP_PATH="$PWD/WebDriverAgentRunner-Runner.app"
+          APP_PATH="WebDriverAgent/WebDriverAgentRunner-Runner.app"
 
           echo "Checking bundle identifier..."
           BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "$APP_PATH/Info.plist")

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -27,21 +27,26 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: 🔍 List Available Simulators
+      - name: 🔍 List Available iOS Simulators
         run: |
-          echo "Available iOS Simulators:"
+          echo "Available iOS simulators:"
           xcrun simctl list devices available
 
-      - name: ✅ Boot iPhone 15 Pro (iOS 17.2) Simulator
+      - name: Boot iPhone 15 Pro (iOS 17.2) Simulator
         run: |
-          UDID=$(xcrun simctl list devices available | grep "iPhone 15 Pro (17.2)" | grep -oE '([0-9A-F-]{36})' | head -n 1)
+          UDID=$(xcrun simctl list devices available | \
+            grep -i "iPhone 15 Pro (17.2" | \
+            grep -oE '([0-9A-F-]{36})' | head -n 1)
+
           if [ -z "$UDID" ]; then
-            echo "::error::❌ Could not find iPhone 15 Pro (17.2) simulator"
+            echo "::error::No matching iPhone 15 Pro (iOS 17.2) simulator found!"
             exit 1
           fi
-          echo "Booting Simulator UDID: $UDID"
-          xcrun simctl boot "$UDID" || true
+
+          echo "Booting simulator with UDID: $UDID"
+          xcrun simctl boot "$UDID" || echo "Simulator might already be booted"
           xcrun simctl bootstatus "$UDID" -b
+
           echo "UDID=$UDID" >> $GITHUB_ENV
 
       - name: Wait for iOS Simulator to Boot

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -85,7 +85,7 @@ jobs:
           echo "Checking WebDriverAgentRunner app..."
 
           echo "Simulator UDID: $UDID"
-          APP_PATH="WebDriverAgent/WebDriverAgentRunner-Runner.app"
+          APP_PATH="WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app"
 
           echo "Checking bundle identifier..."
           BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "$APP_PATH/Info.plist")

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -32,11 +32,16 @@ jobs:
           echo "Available iOS Simulators:"
           xcrun simctl list devices available
 
-      - name: Boot iOS Simulator 17.2
+      - name: ✅ Boot iPhone 15 Pro (iOS 17.2) Simulator
         run: |
-          export UDID=$(xcrun simctl list devices available | grep -i "iPhone 15 Pro (17.2)" | grep -oE '([0-9A-F-]{36})' | head -n 1)
+          UDID=$(xcrun simctl list devices available | grep "iPhone 15 Pro (17.2)" | grep -oE '([0-9A-F-]{36})' | head -n 1)
+          if [ -z "$UDID" ]; then
+            echo "::error::❌ Could not find iPhone 15 Pro (17.2) simulator"
+            exit 1
+          fi
           echo "Booting Simulator UDID: $UDID"
-          xcrun simctl boot "$UDID"
+          xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b
           echo "UDID=$UDID" >> $GITHUB_ENV
 
       - name: Wait for iOS Simulator to Boot

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -62,6 +62,9 @@ jobs:
             -configuration Debug \
             build-for-testing | xcpretty      
 
+      - name: Debug: List Built App Contents
+        run: ls -R WebDriverAgent/build/Build/Products/Debug-iphonesimulator
+
       - name: Install and Launch WebDriverAgentRunner on Simulator
         run: |
           echo "Installing WDA to Simulator with UDID=$UDID"

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -34,12 +34,12 @@ jobs:
 
       - name: Boot iPhone 15 Pro (iOS 17.2) Simulator
         run: |
-          UDID=$(xcrun simctl list devices available | grep -i "iPhone 15 Pro" | grep -i "17.2" | awk -F'[()]' '{print $2}' | head -n 1)
-          if [ -z "$UDID" ]; then
-            echo "::error::No matching iPhone 15 Pro (iOS 17.2) simulator found!"
-            exit 1
-          fi
-
+          #UDID=$(xcrun simctl list devices available | grep -i "iPhone 15 Pro" | grep -i "17.2" | awk -F'[()]' '{print $2}' | head -n 1)
+          #if [ -z "$UDID" ]; then
+          #  echo "::error::No matching iPhone 15 Pro (iOS 17.2) simulator found!"
+          #  exit 1
+          #fi
+          UDID=5C4114F9-8311-49E4-A834-4E4ABEDE918F
           echo "Booting simulator with UDID: $UDID"
           xcrun simctl boot "$UDID" || echo "Simulator might already be booted"
           xcrun simctl bootstatus "$UDID" -b

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -124,6 +124,13 @@ jobs:
       - name: Build Code
         run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-ios -c Release --no-restore
 
+      - name: Boot iPhone 15 Pro (iOS 17.2) Simulator Again....
+        run: |
+          UDID=5C4114F9-8311-49E4-A834-4E4ABEDE918F
+          echo "Booting simulator with UDID: $UDID"
+          xcrun simctl boot "$UDID" || echo "Simulator might already be booted"
+          xcrun simctl bootstatus "$UDID" -b
+
       - name: Run iOS Navigation Tests
         run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
 

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: 🧪 Start Appium Server
         run: |
-          nohup appium --base-path /wd/hub > appium.log 2>&1 &
+          nohup appium --log appium.log &
 
       - name: 📱 Create iOS Simulator (if needed)
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -41,7 +41,7 @@ jobs:
           git clone https://github.com/appium/appium-xcuitest-driver.git
           cd appium-xcuitest-driver
           npm install
-          npx appium driver install --source=local --driver $(pwd)
+          npx appium driver install --source=local
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -64,14 +64,19 @@ jobs:
 
       - name: Install and Launch WebDriverAgentRunner on Simulator
         run: |
-          export UDID=$UDID
+          echo "Installing WDA to Simulator with UDID=$UDID"
           APP_PATH="WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app"
           
+          # Just in case: boot again (won't hurt)
+          xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b
+
+          # Install the app
           xcrun simctl install "$UDID" "$APP_PATH"
+          
+          # Launch the app
           xcrun simctl launch "$UDID" com.facebook.WebDriverAgentRunner || echo "WDA launch attempted"
 
-          # Optional: Check logs if debugging
-          xcrun simctl spawn "$UDID" log stream --predicate 'process == "WebDriverAgentRunner"' --style compact --timeout 10
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -65,20 +65,41 @@ jobs:
       - name: Debug List Built App Contents
         run: ls -R WebDriverAgent/build/Build/Products/Debug-iphonesimulator
 
-      - name: Install and Launch WebDriverAgentRunner on Simulator
-        run: |
-          echo "Installing WDA to Simulator with UDID=$UDID"
-          APP_PATH="WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app"
-          
-          # Just in case: boot again (won't hurt)
-          xcrun simctl boot "$UDID" || true
-          xcrun simctl bootstatus "$UDID" -b
+      #- name: Install and Launch WebDriverAgentRunner on Simulator
+      #  run: |
+      #    echo "Installing WDA to Simulator with UDID=$UDID"
+      #    APP_PATH="WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app"
+      #    
+      #    # Just in case: boot again (won't hurt)
+      #    xcrun simctl boot "$UDID" || true
+      #    xcrun simctl bootstatus "$UDID" -b#
 
-          # Install the app
+#          # Install the app
+ #         xcrun simctl install "$UDID" "$APP_PATH"
+  #        
+   #       # Launch the app
+    #      xcrun simctl launch "$UDID" com.facebook.WebDriverAgentRunner || echo "WDA launch attempted"
+
+      - name: Debug WebDriverAgent App Install and Bundle ID
+        run: |
+          echo "Checking WebDriverAgentRunner app..."
+
+          echo "Simulator UDID: $UDID"
+          APP_PATH="$PWD/WebDriverAgentRunner-Runner.app"
+
+          echo "Checking bundle identifier..."
+          BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "$APP_PATH/Info.plist")
+          echo "Extracted Bundle ID: $BUNDLE_ID"
+
+          echo "Installing WDA app to simulator..."
           xcrun simctl install "$UDID" "$APP_PATH"
-          
-          # Launch the app
-          xcrun simctl launch "$UDID" com.facebook.WebDriverAgentRunner || echo "WDA launch attempted"
+
+          echo "Verifying install..."
+          INSTALLED_APPS=$(xcrun simctl get_app_container "$UDID" "$BUNDLE_ID" 2>&1 || echo "App not found")
+          echo "App container: $INSTALLED_APPS"
+
+          echo "Launching WebDriverAgent..."
+          xcrun simctl launch "$UDID" "$BUNDLE_ID"
 
 
       - name: Start Appium Server

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -35,7 +35,13 @@ jobs:
       - name: Install Appium and Drivers
         run: |
           npm install -g appium --unsafe-perm=true --allow-root
-          appium driver install xcuitest@next
+
+      - name: Install Appium XCUITest Driver from GitHub
+        run: |
+          git clone https://github.com/appium/appium-xcuitest-driver.git
+          cd appium-xcuitest-driver
+          npm install
+          npx appium driver install --source=local --driver $(pwd)
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -26,7 +26,20 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '8.0.x'
-     
+
+      - name: Boot Existing iOS Simulator
+        run: |
+          export UDID=$(xcrun simctl list devices available | grep "iPhone" | grep -oE '([0-9A-F-]{36})' | head -n 1)
+          echo "Booting Simulator UDID: $UDID"
+          xcrun simctl boot "$UDID"
+
+      - name: Wait for iOS Simulator to Boot
+        run: |
+          export UDID=$(xcrun simctl list devices booted | grep -oE '([0-9A-F-]{36})' | head -n 1)
+          echo "Using Simulator UDID: $UDID"
+          xcrun simctl bootstatus "$UDID" -b
+          echo "UDID=$UDID" >> $GITHUB_ENV
+
       - name: Install MAUI Workloads
         run: |
           dotnet workload install ios --ignore-failed-sources

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -61,7 +61,6 @@ jobs:
         run: |
           git clone https://github.com/appium/appium-xcuitest-driver.git
           cd appium-xcuitest-driver
-          git checkout 0a67193f276d55e2b5e76b20f75b3e8d85e04714  # Known working commit
           npm install
           mkdir -p ~/.appium/node_modules/
           cp -R . ~/.appium/node_modules/appium-xcuitest-driver          

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -41,7 +41,8 @@ jobs:
           git clone https://github.com/appium/appium-xcuitest-driver.git
           cd appium-xcuitest-driver
           npm install
-          npx appium driver update --source=local ./
+          node ./scripts/build-driver.js
+          npx appium driver install --source=local $(pwd)
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -8,110 +8,49 @@ on:
 jobs:
   software_navigation_tests:
     runs-on: macos-14
+    env:
+      PLATFORM_VERSION: "17.2"
+      DEVICE_NAME: "iPhone 15"
+      APP_PATH: "./MyTestApp.app"
+
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - name: 🧾 Checkout repo
+        uses: actions/checkout@v4
 
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+      - name: 🔧 Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          xcode-version: '16.2' # Update as needed based on available versions
+          node-version: '20'
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '18'
-
-      - name: Set up .NET
-        uses: actions/setup-dotnet@v1
+      - name: 🔧 Set up .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
 
-      - name: 🔍 List Available iOS Simulators
+      - name: 📦 Install Appium + XCUITest driver
         run: |
-          echo "Available iOS simulators:"
-          xcrun simctl list devices available
+          npm install -g appium
+          appium driver install xcuitest
 
-      - name: Boot iPhone 15 Pro (iOS 17.2) Simulator
+      - name: 🧹 Clean DerivedData and WDA cache
         run: |
-          #UDID=$(xcrun simctl list devices available | grep -i "iPhone 15 Pro" | grep -i "17.2" | awk -F'[()]' '{print $2}' | head -n 1)
-          #if [ -z "$UDID" ]; then
-          #  echo "::error::No matching iPhone 15 Pro (iOS 17.2) simulator found!"
-          #  exit 1
-          #fi
-          UDID=5C4114F9-8311-49E4-A834-4E4ABEDE918F
-          echo "Booting simulator with UDID: $UDID"
-          xcrun simctl boot "$UDID" || echo "Simulator might already be booted"
-          xcrun simctl bootstatus "$UDID" -b
+          rm -rf ~/Library/Developer/Xcode/DerivedData
+          rm -rf ~/.appium/node_modules/appium-webdriveragent/Build
 
-          echo "UDID=$UDID" >> $GITHUB_ENV
-
-      - name: Wait for iOS Simulator to Boot
+      - name: 🧪 Start Appium Server
         run: |
-          export UDID=$(xcrun simctl list devices booted | grep -oE '([0-9A-F-]{36})' | head -n 1)
-          echo "Using Simulator UDID: $UDID"
-          xcrun simctl bootstatus "$UDID" -b
-          echo "UDID=$UDID" >> $GITHUB_ENV
+          nohup appium --base-path /wd/hub > appium.log 2>&1 &
 
-      - name: Clone WebDriverAgent
+      - name: 📱 Create iOS Simulator (if needed)
         run: |
-          git clone https://github.com/appium/WebDriverAgent.git
-          cd WebDriverAgent
-          git checkout v9.4.1
+          SIMULATOR_NAME="ci-sim-$RANDOM"
+          xcrun simctl create "$SIMULATOR_NAME" "$DEVICE_NAME" "com.apple.CoreSimulator.SimRuntime.iOS-${PLATFORM_VERSION//./-}"
+          echo "SIMULATOR_NAME=$SIMULATOR_NAME" >> $GITHUB_ENV
 
-      - name: Build WebDriverAgent for Simulator
+      - name: 🚀 Boot simulator
         run: |
-          set -e
-          export UDID=$UDID
-          echo "Target Simulator UDID: $UDID"
-
-          # Navigate into WebDriverAgent
-          cd WebDriverAgent
-          mkdir -p build
-
-          echo "Building WebDriverAgentRunner with manual signing disabled..."
-
-          xcodebuild -scheme WebDriverAgentRunner \
-            -destination "id=$UDID" \
-            -derivedDataPath build \
-            -configuration Debug \
-            -allowProvisioningUpdates \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            DEVELOPMENT_TEAM="" \
-            PRODUCT_BUNDLE_IDENTIFIER=com.appium.WebDriverAgentRunner \
-            build-for-testing | xcpretty
-                
-      - name: Debug WebDriverAgent App Install and Bundle ID
-        run: |
-          echo "Checking WebDriverAgentRunner app..."
-
-          echo "Simulator UDID: $UDID"
-          APP_PATH="WebDriverAgent/build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app"
-
-          echo "Checking bundle identifier..."
-          BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "$APP_PATH/Info.plist")
-          echo "Extracted Bundle ID: $BUNDLE_ID"
-
-          echo "Installing WDA app to simulator..."
-          xcrun simctl install "$UDID" "$APP_PATH"
-
-          echo "Verifying install..."
-          INSTALLED_APPS=$(xcrun simctl get_app_container "$UDID" "$BUNDLE_ID" 2>&1 || echo "App not found")
-          echo "App container: $INSTALLED_APPS"
-
-          echo "Launching WebDriverAgent..."
-          xcrun simctl launch "$UDID" "$BUNDLE_ID"
-
-      - name: Install Appium XCUITest Driver from GitHub
-        run: |
-          npm install -g appium --unsafe-perm=true --allow-root
-          appium driver install --source=git --package=appium-xcuitest-driver https://github.com/appium/appium-xcuitest-driver.git
-
-      - name: Start Appium Server
-        run: |
-          nohup appium --log appium.log &
+          xcrun simctl boot "$SIMULATOR_NAME"
+          xcrun simctl list | grep Booted
 
       - name: Install MAUI Workloads
         run: |
@@ -124,17 +63,16 @@ jobs:
       - name: Build Code
         run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-ios -c Release --no-restore
 
-      - name: Boot iPhone 15 Pro (iOS 17.2) Simulator Again....
-        run: |
-          UDID=5C4114F9-8311-49E4-A834-4E4ABEDE918F
-          echo "Booting simulator with UDID: $UDID"
-          xcrun simctl boot "$UDID" || echo "Simulator might already be booted"
-          xcrun simctl bootstatus "$UDID" -b
-
       - name: Run iOS Navigation Tests
         run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
 
-      - name: Upload Appium Logs on Failure
+      - name: 🧼 Shutdown simulator
+        if: always()
+        run: |
+          xcrun simctl shutdown "$SIMULATOR_NAME"
+          xcrun simctl delete "$SIMULATOR_NAME"
+
+      - name: Upload Appium Logs on Failure      
         if: failure()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -41,8 +41,7 @@ jobs:
           git clone https://github.com/appium/appium-xcuitest-driver.git
           cd appium-xcuitest-driver
           npm install
-          node ./scripts/build-driver.js
-          npx appium driver install --source=local $(pwd)
+          npx appium driver install --source=local .
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -41,7 +41,8 @@ jobs:
           git clone https://github.com/appium/appium-xcuitest-driver.git
           cd appium-xcuitest-driver
           npm install
-          npx appium driver update --source=local .
+          mkdir -p ~/.appium/node_modules/
+          cp -R . ~/.appium/node_modules/appium-xcuitest-driver
 
       - name: Start Appium Server
         run: |

--- a/TransactionMobile.Maui.BusinessLogic/ViewModels/HomePageViewModel.cs
+++ b/TransactionMobile.Maui.BusinessLogic/ViewModels/HomePageViewModel.cs
@@ -36,6 +36,7 @@ public class HomePageViewModel : ExtendedBaseViewModel
 
     #region Methods
 
+#if !IOS
     public async Task Initialise(CancellationToken cancellationToken) {
         Configuration configuration = this.ApplicationCache.GetConfiguration();
 
@@ -59,13 +60,14 @@ public class HomePageViewModel : ExtendedBaseViewModel
             Logger.LogError("Error during initialise", ex);
         }
     }
+#endif
 
     private async void NoReleaseAvailable() {
         await this.DialogService.ShowDialog("Software Update", "No Release Available","OK");
     }
 
-    //private Boolean IsIOS() => this.DeviceService.IsIOS//DeviceInfo.Current.Platform == DevicePlatform.iOS;
 
+#if !IOS
     private Boolean OnReleaseAvailable(ReleaseDetails releaseDetails) {
         Logger.LogInformation("In OnReleaseAvailable");
         // Look at releaseDetails public properties to get version information, release notes text or release notes URL
@@ -111,6 +113,7 @@ public class HomePageViewModel : ExtendedBaseViewModel
         // Return true if you're using your own dialog, false otherwise
         return true;
     }
+#endif
 
-    #endregion
+#endregion
 }

--- a/TransactionMobile.Maui.BusinessLogic/ViewModels/HomePageViewModel.cs
+++ b/TransactionMobile.Maui.BusinessLogic/ViewModels/HomePageViewModel.cs
@@ -3,8 +3,10 @@
 using System.Diagnostics.CodeAnalysis;
 using Logging;
 using Maui.UIServices;
+#if !IOS
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Distribute;
+#endif
 using Models;
 using Services;
 using UIServices;

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -34,10 +34,10 @@ namespace TransactionMobile.Maui.UiTests.Drivers
         public static AppiumDriver Driver;
 
         public void StartApp() {
-            OptionCollector o = new OptionCollector();
-            o.AddArguments(GeneralOptionList.BasePath("/wd/hub"));
+            //OptionCollector o = new OptionCollector();
+            //o.AddArguments(GeneralOptionList.BasePath("/wd/hub"));
             AppiumLocalService appiumService = new AppiumServiceBuilder().UsingPort(4723)
-                .WithArguments(o)
+                //.WithArguments(o)
                 .Build();
             
             if (appiumService.IsRunning == false){

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -83,6 +83,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             driverOptions.App = apkPath;
             driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
             driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
+            driverOptions.AddAdditionalAppiumOption("shouldWaitForQuiescence", false);
             //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, true);
             //driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
             //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 999999999);

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -82,7 +82,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
             driverOptions.App = apkPath;
             driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
-            driverOptions.AddAdditionalOption("waitForQuiescence", false);
+            driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
             //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, true);
             //driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
             //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 999999999);

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -91,6 +91,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             //driverOptions.AddAdditionalAppiumOption("restart", true);
             //driverOptions.AddAdditionalAppiumOption("simulatorStartupTimeout", 5 * 60 * 1000);
 
+
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
         }
 

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -119,7 +119,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             //// (Optional but often helpful)
             //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
             //driverOptions.AddAdditionalAppiumOption("startIWDP", true); // if you want to inspect webviews
-
+            driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, false);
             driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
             driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100); // optional, but helpful
             driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true); // avoids extra processes

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -77,7 +77,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             driverOptions.DeviceName = "iPhone 11";
             
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-x64/");
+            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-arm64/");
             var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
             driverOptions.App = apkPath;
             driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -120,6 +120,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
             //driverOptions.AddAdditionalAppiumOption("startIWDP", true); // if you want to inspect webviews
             driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, false);
+            driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NoReset, true);
             driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
             driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100); // optional, but helpful
             driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true); // avoids extra processes

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -107,6 +107,10 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
             driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true);
 
+            driverOptions.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/work/WebDriverAgent/build/Build/Products/Debug-iphonesimulator");
+            driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100);
+
+
             // Avoid unnecessary WDA rebuild attempts and add resilience
             driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
             driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 3);

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -97,7 +97,9 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
             driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
             driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 4);
-
+            driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            driverOptions.AddAdditionalAppiumOption("derivedDataPath", Environment.GetEnvironmentVariable("WDA_PATH"));
+            driverOptions.AddAdditionalAppiumOption("updatedWDABundleId", "com.facebook.WebDriverAgentRunner");
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
         }

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -92,13 +92,15 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             //driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
             //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
             //driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 60000);
-            driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 120000);
-            driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 120000);
-            driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
-            driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
-            driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 4);
+            //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 120000);
+            //driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 120000);
+            //driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
+            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 4);
             driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            driverOptions.AddAdditionalAppiumOption("derivedDataPath", Environment.GetEnvironmentVariable("WDA_PATH"));
+            driverOptions.AddAdditionalAppiumOption("skipServerInstallation", true);
+            driverOptions.AddAdditionalAppiumOption("skipProvisioningDeviceDetection", true);
+            driverOptions.AddAdditionalAppiumOption("wdaLocalPort", Environment.GetEnvironmentVariable("WDA_PATH"));
             driverOptions.AddAdditionalAppiumOption("updatedWDABundleId", "com.facebook.WebDriverAgentRunner");
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -8,11 +8,13 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
 
 namespace TransactionMobile.Maui.UiTests.Drivers
 {
     using Microsoft.Testing.Platform.Capabilities;
     using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Service.Options;
     using OpenQA.Selenium.Appium.Windows;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
@@ -31,8 +33,11 @@ namespace TransactionMobile.Maui.UiTests.Drivers
         public static MobileTestPlatform MobileTestPlatform;
         public static AppiumDriver Driver;
 
-        public void StartApp(){
+        public void StartApp() {
+            OptionCollector o = new OptionCollector();
+            o.AddArguments(GeneralOptionList.BasePath("/wd/hub"));
             AppiumLocalService appiumService = new AppiumServiceBuilder().UsingPort(4723)
+                .WithArguments(o)
                 .Build();
             
             if (appiumService.IsRunning == false){

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -11,11 +11,12 @@ using System.Threading.Tasks;
 
 namespace TransactionMobile.Maui.UiTests.Drivers
 {
+    using Microsoft.Testing.Platform.Capabilities;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
     using System.Threading;
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Appium.Windows;
     
     public enum MobileTestPlatform
     {
@@ -81,6 +82,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
             driverOptions.App = apkPath;
             driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
+            driverOptions.AddAdditionalOption("waitForQuiescence", false);
             //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, true);
             //driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
             //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 999999999);

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -103,22 +103,29 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", Environment.GetEnvironmentVariable("WDA_PATH"));
             //driverOptions.AddAdditionalAppiumOption("updatedWDABundleId", "WebDriverAgent/build");
             // Tell Appium to use the prebuilt WDA
+            //driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            //driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
+            //driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true);
+
+            //driverOptions.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/work/WebDriverAgent/build/Build/Products/Debug-iphonesimulator");
+            //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100);
+
+
+            //// Avoid unnecessary WDA rebuild attempts and add resilience
+            //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
+            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 3);
+            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+
+            //// (Optional but often helpful)
+            //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
+            //driverOptions.AddAdditionalAppiumOption("startIWDP", true); // if you want to inspect webviews
+
             driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
-            driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true);
+            driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100); // optional, but helpful
+            driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true); // avoids extra processes
+            driverOptions.AddAdditionalAppiumOption("showXcodeLog", true); // shows build errors in logs
+            driverOptions.AddAdditionalAppiumOption("bundleId", "com.appium.WebDriverAgentRunner"); // match WDA bundle ID
 
-            driverOptions.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/work/WebDriverAgent/build/Build/Products/Debug-iphonesimulator");
-            driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100);
-
-
-            // Avoid unnecessary WDA rebuild attempts and add resilience
-            driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
-            driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 3);
-            driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
-
-            // (Optional but often helpful)
-            driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
-            driverOptions.AddAdditionalAppiumOption("startIWDP", true); // if you want to inspect webviews
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
         }

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -88,13 +88,10 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
             driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
             driverOptions.AddAdditionalAppiumOption("shouldWaitForQuiescence", false);
-            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, true);
-            //driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
-            //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 999999999);
-            //driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 999999999);
-            //driverOptions.AddAdditionalAppiumOption("restart", true);
-            //driverOptions.AddAdditionalAppiumOption("simulatorStartupTimeout", 5 * 60 * 1000);
-
+            driverOptions.AddAdditionalAppiumOption("showXcodeLog", true);
+            driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
+            driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
+            driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 60000);
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
         }

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -73,7 +73,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             var driverOptions = new AppiumOptions();
             driverOptions.AutomationName = "XCUITest";
             driverOptions.PlatformName = "iOS";
-            driverOptions.PlatformVersion = "15.4";
+            driverOptions.PlatformVersion = "17.4";
             driverOptions.DeviceName = "iPhone 11";
             
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -85,23 +85,36 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-arm64/");
             var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
             driverOptions.App = apkPath;
-            driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
-            driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
-            driverOptions.AddAdditionalAppiumOption("shouldWaitForQuiescence", false);
-            driverOptions.AddAdditionalAppiumOption("showXcodeLog", true);
-            //driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
-            //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
-            //driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 60000);
-            //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 120000);
-            //driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 120000);
-            //driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
-            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
-            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 4);
+            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
+            //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
+            //driverOptions.AddAdditionalAppiumOption("shouldWaitForQuiescence", false);
+            //driverOptions.AddAdditionalAppiumOption("showXcodeLog", true);
+            ////driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
+            ////driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
+            ////driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 60000);
+            ////driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 120000);
+            ////driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 120000);
+            ////driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
+            ////driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+            ////driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 4);
+            //driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            //driverOptions.AddAdditionalAppiumOption("skipServerInstallation", true);
+            //driverOptions.AddAdditionalAppiumOption("skipProvisioningDeviceDetection", true);
+            //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", Environment.GetEnvironmentVariable("WDA_PATH"));
+            //driverOptions.AddAdditionalAppiumOption("updatedWDABundleId", "WebDriverAgent/build");
+            // Tell Appium to use the prebuilt WDA
             driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            driverOptions.AddAdditionalAppiumOption("skipServerInstallation", true);
-            driverOptions.AddAdditionalAppiumOption("skipProvisioningDeviceDetection", true);
-            driverOptions.AddAdditionalAppiumOption("wdaLocalPort", Environment.GetEnvironmentVariable("WDA_PATH"));
-            driverOptions.AddAdditionalAppiumOption("updatedWDABundleId", "WebDriverAgent/build");
+            driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
+            driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true);
+
+            // Avoid unnecessary WDA rebuild attempts and add resilience
+            driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
+            driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 3);
+            driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+
+            // (Optional but often helpful)
+            driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
+            driverOptions.AddAdditionalAppiumOption("startIWDP", true); // if you want to inspect webviews
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
         }

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -71,20 +71,34 @@ namespace TransactionMobile.Maui.UiTests.Drivers
         }
 
         private static void SetupiOSDriver(AppiumLocalService appiumService) {
-            var driverOptions = new AppiumOptions();
-            driverOptions.AutomationName = "XCUITest";
-            //driverOptions.PlatformName = "iOS";
-            //driverOptions.PlatformVersion = "17.4";
-            //driverOptions.DeviceName = "iPhone 11";
-            driverOptions.AutomationName = "XCUITest";
-            driverOptions.PlatformName = "iOS";
-            driverOptions.PlatformVersion = "17.2";
-            driverOptions.AddAdditionalAppiumOption("udid", Environment.GetEnvironmentVariable("UDID")); // Corrected capability.
-
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-arm64/");
             var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
-            driverOptions.App = apkPath;
+            
+            var caps = new AppiumOptions();
+            caps.PlatformName = "iOS";
+            caps.PlatformVersion = "17.4";
+            caps.DeviceName = "iPhone 15";
+            caps.AutomationName = "XCUITest";
+            caps.App = apkPath;
+            caps.AddAdditionalAppiumOption("fullReset", true);
+            caps.AddAdditionalAppiumOption("noReset", false);
+            caps.AddAdditionalAppiumOption("useNewWDA", true);
+
+            //var driverOptions = new AppiumOptions();
+            //driverOptions.AutomationName = "XCUITest";
+            ////driverOptions.PlatformName = "iOS";
+            ////driverOptions.PlatformVersion = "17.4";
+            ////driverOptions.DeviceName = "iPhone 11";
+            //driverOptions.AutomationName = "XCUITest";
+            //driverOptions.PlatformName = "iOS";
+            //driverOptions.PlatformVersion = "17.2";
+            //driverOptions.AddAdditionalAppiumOption("udid", Environment.GetEnvironmentVariable("UDID")); // Corrected capability.
+
+            //String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            //String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-arm64/");
+            //var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
+            //driverOptions.App = apkPath;
             //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
             //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
             //driverOptions.AddAdditionalAppiumOption("shouldWaitForQuiescence", false);
@@ -119,16 +133,16 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             //// (Optional but often helpful)
             //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
             //driverOptions.AddAdditionalAppiumOption("startIWDP", true); // if you want to inspect webviews
-            driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, false);
-            driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NoReset, true);
-            driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100); // optional, but helpful
-            driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true); // avoids extra processes
-            driverOptions.AddAdditionalAppiumOption("showXcodeLog", true); // shows build errors in logs
-            driverOptions.AddAdditionalAppiumOption("bundleId", "com.appium.WebDriverAgentRunner"); // match WDA bundle ID
+            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, false);
+            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NoReset, true);
+            //driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100); // optional, but helpful
+            //driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true); // avoids extra processes
+            //driverOptions.AddAdditionalAppiumOption("showXcodeLog", true); // shows build errors in logs
+            //driverOptions.AddAdditionalAppiumOption("bundleId", "com.appium.WebDriverAgentRunner"); // match WDA bundle ID
 
 
-            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
+            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, caps, TimeSpan.FromMinutes(10));
         }
 
         private static void SetupAndroidDriver(AppiumLocalService appiumService) {

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -101,7 +101,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             driverOptions.AddAdditionalAppiumOption("skipServerInstallation", true);
             driverOptions.AddAdditionalAppiumOption("skipProvisioningDeviceDetection", true);
             driverOptions.AddAdditionalAppiumOption("wdaLocalPort", Environment.GetEnvironmentVariable("WDA_PATH"));
-            driverOptions.AddAdditionalAppiumOption("updatedWDABundleId", "com.facebook.WebDriverAgentRunner");
+            driverOptions.AddAdditionalAppiumOption("updatedWDABundleId", "WebDriverAgent/build");
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
         }

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -73,10 +73,14 @@ namespace TransactionMobile.Maui.UiTests.Drivers
         private static void SetupiOSDriver(AppiumLocalService appiumService) {
             var driverOptions = new AppiumOptions();
             driverOptions.AutomationName = "XCUITest";
+            //driverOptions.PlatformName = "iOS";
+            //driverOptions.PlatformVersion = "17.4";
+            //driverOptions.DeviceName = "iPhone 11";
+            driverOptions.AutomationName = "XCUITest";
             driverOptions.PlatformName = "iOS";
-            driverOptions.PlatformVersion = "17.4";
-            driverOptions.DeviceName = "iPhone 11";
-            
+            driverOptions.PlatformVersion = "17.2";
+            driverOptions.AddAdditionalAppiumOption("udid", Environment.GetEnvironmentVariable("UDID")); // Corrected capability.
+
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-arm64/");
             var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -89,9 +89,15 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
             driverOptions.AddAdditionalAppiumOption("shouldWaitForQuiescence", false);
             driverOptions.AddAdditionalAppiumOption("showXcodeLog", true);
-            driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
-            driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
-            driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 60000);
+            //driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
+            //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
+            //driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 60000);
+            driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 120000);
+            driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 120000);
+            driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
+            driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+            driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 4);
+
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
         }

--- a/TransactionMobile.Maui.UiTests/Features/PageNavigation.feature
+++ b/TransactionMobile.Maui.UiTests/Features/PageNavigation.feature
@@ -20,7 +20,7 @@ Scenario: Back Button from Home Page Screen
 	Then the Login Page is displayed
 
 # Transaction Page Back Button Tests
-#@PRNavTest
+@PRNavTest
 Scenario: Back Button from Transaction Page Screen
 	Given I am on the Login Screen
 	And the application is in training mode
@@ -38,7 +38,7 @@ Scenario: Back Button from Transaction Page Screen
 	Then the Merchant Home Page is displayed	
 
 # Reports Page Back Button Tests
-#@PRNavTest
+@PRNavTest
 Scenario: Back Button from Reports Page Screen
 	Given I am on the Login Screen
 	And the application is in training mode
@@ -56,7 +56,7 @@ Scenario: Back Button from Reports Page Screen
 	Then the Merchant Home Page is displayed	
 
 # Profile Page Back Button Tests
-#@PRNavTest
+@PRNavTest
 Scenario: Back Button from Profile Page Screen
 	Given I am on the Login Screen
 	And the application is in training mode
@@ -82,7 +82,7 @@ Scenario: Back Button from Profile Page Screen
 	Then the Merchant Home Page is displayed
 
 # Support Page Back Button Tests
-#@PRNavTest
+@PRNavTest
 Scenario: Back Button from Support Page Screen
 	Given I am on the Login Screen
 	And the application is in training mode

--- a/TransactionMobile.Maui.UiTests/Features/PageNavigation.feature
+++ b/TransactionMobile.Maui.UiTests/Features/PageNavigation.feature
@@ -20,7 +20,7 @@ Scenario: Back Button from Home Page Screen
 	Then the Login Page is displayed
 
 # Transaction Page Back Button Tests
-@PRNavTest
+#@PRNavTest
 Scenario: Back Button from Transaction Page Screen
 	Given I am on the Login Screen
 	And the application is in training mode
@@ -38,7 +38,7 @@ Scenario: Back Button from Transaction Page Screen
 	Then the Merchant Home Page is displayed	
 
 # Reports Page Back Button Tests
-@PRNavTest
+#@PRNavTest
 Scenario: Back Button from Reports Page Screen
 	Given I am on the Login Screen
 	And the application is in training mode
@@ -56,7 +56,7 @@ Scenario: Back Button from Reports Page Screen
 	Then the Merchant Home Page is displayed	
 
 # Profile Page Back Button Tests
-@PRNavTest
+#@PRNavTest
 Scenario: Back Button from Profile Page Screen
 	Given I am on the Login Screen
 	And the application is in training mode
@@ -82,7 +82,7 @@ Scenario: Back Button from Profile Page Screen
 	Then the Merchant Home Page is displayed
 
 # Support Page Back Button Tests
-@PRNavTest
+#@PRNavTest
 Scenario: Back Button from Support Page Screen
 	Given I am on the Login Screen
 	And the application is in training mode

--- a/TransactionMobile.Maui.UiTests/Pages/LoginPage.cs
+++ b/TransactionMobile.Maui.UiTests/Pages/LoginPage.cs
@@ -107,15 +107,18 @@ public class LoginPage : BasePage2
     public async Task EnterPassword(String password)
     {
         IWebElement element = await this.WaitForElementByAccessibilityId(this.PasswordEntry);
-        
-        
         element.SendKeys(password);
     }
 
     public async Task ClickLoginButton(){
         await Retry.For(async () => {
                             IWebElement element = await this.WaitForElementByAccessibilityId(this.LoginButton);
-                            //element.Displayed.ShouldBeTrue();
+                            if (element.Displayed == false)
+                            {
+                                this.HideKeyboard();
+                            }
+                            
+                            element.Displayed.ShouldBeTrue();
                             element.Click();
                         });
 

--- a/TransactionMobile.Maui.UiTests/Pages/LoginPage.cs
+++ b/TransactionMobile.Maui.UiTests/Pages/LoginPage.cs
@@ -118,7 +118,7 @@ public class LoginPage : BasePage2
                                 this.HideKeyboard();
                             }
                             
-                            element.Displayed.ShouldBeTrue();
+                            //element.Displayed.ShouldBeTrue();
                             element.Click();
                         });
 

--- a/TransactionMobile.Maui.UiTests/Steps/LoginSteps.cs
+++ b/TransactionMobile.Maui.UiTests/Steps/LoginSteps.cs
@@ -93,7 +93,14 @@ namespace TransactionMobile.Maui.UITests.Steps
 
         [Then(@"the Merchant Home Page is displayed")]
         public async Task ThenTheMerchantHomePageIsDisplayed() {
-            await this.mainPage.AssertOnPage();
+            try {
+                await this.mainPage.AssertOnPage();
+            }
+            catch(Exception ex)
+            {
+                String pageSource = await this.mainPage.GetPageSource();
+                throw new Exception($"Unable to verify on page: {this.mainPage.GetType().Name} {Environment.NewLine} Page Source: {pageSource}", ex);
+            }
         }
 
         [Then(@"the available balance is shown as (.*)")]

--- a/TransactionMobile.Maui.UiTests/Steps/LoginSteps.cs
+++ b/TransactionMobile.Maui.UiTests/Steps/LoginSteps.cs
@@ -59,6 +59,9 @@ namespace TransactionMobile.Maui.UITests.Steps
 
             if (isTrainingModeOn == false)
                 await this.loginPage.SetTrainingModeOn();
+
+            var isOn = this.loginPage.IsTrainingModeOn();
+            Console.WriteLine($"Training Mode is {isOn}");
         }
 
         [When(@"I enter '(.*)' as the Email Address")]

--- a/TransactionMobile.Maui.UiTests/Steps/LoginSteps.cs
+++ b/TransactionMobile.Maui.UiTests/Steps/LoginSteps.cs
@@ -56,12 +56,8 @@ namespace TransactionMobile.Maui.UITests.Steps
         [Given(@"the application is in training mode")]
         public async Task GivenTheApplicationIsInTrainingMode() {
             var isTrainingModeOn = await this.loginPage.IsTrainingModeOn();
-            isTrainingModeOn.ShouldBe(false);
             if (isTrainingModeOn == false)
                 await this.loginPage.SetTrainingModeOn();
-
-            var isOn = await this.loginPage.IsTrainingModeOn();
-            isOn.ShouldBe(true);
         }
 
         [When(@"I enter '(.*)' as the Email Address")]

--- a/TransactionMobile.Maui.UiTests/Steps/LoginSteps.cs
+++ b/TransactionMobile.Maui.UiTests/Steps/LoginSteps.cs
@@ -56,12 +56,12 @@ namespace TransactionMobile.Maui.UITests.Steps
         [Given(@"the application is in training mode")]
         public async Task GivenTheApplicationIsInTrainingMode() {
             var isTrainingModeOn = await this.loginPage.IsTrainingModeOn();
-
+            isTrainingModeOn.ShouldBe(false);
             if (isTrainingModeOn == false)
                 await this.loginPage.SetTrainingModeOn();
 
-            var isOn = this.loginPage.IsTrainingModeOn();
-            Console.WriteLine($"Training Mode is {isOn}");
+            var isOn = await this.loginPage.IsTrainingModeOn();
+            isOn.ShouldBe(true);
         }
 
         [When(@"I enter '(.*)' as the Email Address")]


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow named "Build and Run iOS Navigation Tests." The workflow is triggered on pull requests to the `main` branch and runs on macOS 14. It includes steps for checking out the repository, setting up Xcode, Node.js, and .NET, installing MAUI workloads, installing Appium and its drivers, starting the Appium server, restoring the MAUI app for iOS, building the code, running iOS navigation tests, and uploading Appium logs on failure.