### PR TITLE
Upgrade to .NET 9.0 across project files and workflows

### DIFF
--- a/.github/workflows/android_e2e_tests.yml
+++ b/.github/workflows/android_e2e_tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -157,7 +157,7 @@ jobs:
         run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
 
       - name: Build Code
-        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-android -c Release --no-restore
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net9.0-android -c Release --no-restore
 
       - name: Run Android Navigation Tests
         run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRTest)&(Category=Android)" --no-restore

--- a/.github/workflows/android_navigation_tests.yml
+++ b/.github/workflows/android_navigation_tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -144,7 +144,7 @@ jobs:
         run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
 
       - name: Build Code
-        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-android -c Release --no-restore
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net9.0-android -c Release --no-restore
 
       - name: Run Android Navigation Tests
         run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRNavTest)&(Category=Android)" --no-restore
@@ -165,7 +165,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -294,7 +294,7 @@ jobs:
         run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
 
       - name: Build Code
-        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-android -c Release --no-restore
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net9.0-android -c Release --no-restore
 
       - name: Run Android Navigation Tests
         run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRHWNavTest)&(Category=Android)" --no-restore

--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -31,10 +31,10 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}     
         shell: bash
 
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x  
+          dotnet-version: 9.0.x  
           
       - name: Install MAUI Workload
         run: dotnet workload install maui --ignore-failed-sources 
@@ -50,13 +50,13 @@ jobs:
           isWindows: false
 
       - name: Build Android
-        run: dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net8.0-android --no-restore /p:AndroidSigningKeyStore=transactionprocessing.keystore /p:AndroidSigningKeyPass="${{ secrets.KEYSTORE_PASSWORD }}" 
+        run: dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net9.0-android --no-restore /p:AndroidSigningKeyStore=transactionprocessing.keystore /p:AndroidSigningKeyPass="${{ secrets.KEYSTORE_PASSWORD }}" 
       
       - name: Upload Android Artifact
         uses: actions/upload-artifact@v3
         with:
           name: android-ci-build
-          path: TransactionMobile.Maui/bin/Release/net8.0-android/com.transactionprocessing.pos-Signed.apk
+          path: TransactionMobile.Maui/bin/Release/net9.0-android/com.transactionprocessing.pos-Signed.apk
           
       - name: Upload Artifact to App Center
         uses: Coxxs/AppCenter-Github-Action@v1
@@ -64,7 +64,7 @@ jobs:
           appName: "Transaction-Processing/POS-Android"
           token: ${{secrets.APPCENTER_ANDROID_TOKEN}}
           group: Merchants
-          file: TransactionMobile.Maui/bin/Release/net8.0-android/com.transactionprocessing.pos-Signed.apk
+          file: TransactionMobile.Maui/bin/Release/net9.0-android/com.transactionprocessing.pos-Signed.apk
           notifyTesters: true
           debug: false  
           gitReleaseNotes: true
@@ -84,10 +84,10 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}        
         shell: bash
        
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x 
+          dotnet-version: 9.0.x 
          
       - name: Install MAUI Workload
         run: dotnet workload install maui --ignore-failed-sources
@@ -103,13 +103,13 @@ jobs:
           isWindows: true
 
       - name: Build Windows
-        run: dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net8.0-windows10.0.19041.0 --no-restore
+        run: dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net9.0-windows10.0.19041.0 --no-restore
 
       - name: Upload Windows Artifact
         uses: actions/upload-artifact@v3
         with:
           name: windows-ci-build
-          path: TransactionMobile.Maui/bin/Release/net8.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile*/TransactionMobile*.msix
+          path: TransactionMobile.Maui/bin/Release/net9.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile*/TransactionMobile*.msix
           
       - name: Upload Artifact to App Center
         uses: Coxxs/AppCenter-Github-Action@v1
@@ -117,7 +117,7 @@ jobs:
           appName: "Transaction-Processing/POS-Windows"
           token: ${{secrets.APPCENTER_WINDOWS_TOKEN}}
           group: Merchants
-          file: "TransactionMobile.Maui/bin/Release/net8.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile.Maui_${{ steps.get_version.outputs.VERSION }}.0_Test/TransactionMobile.Maui_${{ steps.get_version.outputs.VERSION }}.0_x64.msix"	
+          file: "TransactionMobile.Maui/bin/Release/net9.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile.Maui_${{ steps.get_version.outputs.VERSION }}.0_Test/TransactionMobile.Maui_${{ steps.get_version.outputs.VERSION }}.0_x64.msix"	
           notifyTesters: true
           debug: false  
           gitReleaseNotes: true          
@@ -133,10 +133,10 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}        
         
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
           
       - name: Install MAUI Workload
         run: dotnet workload install maui --ignore-failed-sources
@@ -152,13 +152,13 @@ jobs:
           isWindows: false
 
       - name: Build MacCatalyst
-        run: dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net8.0-maccatalyst --no-restore
+        run: dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net9.0-maccatalyst --no-restore
 
       - name: Upload MacCatalyst Artifact
         uses: actions/upload-artifact@v3
         with:
           name: macos-ci-build
-          path: TransactionMobile.Maui/bin/Release/net8.0-maccatalyst/maccatalyst-x64/publish/*.pkg
+          path: TransactionMobile.Maui/bin/Release/net9.0-maccatalyst/maccatalyst-x64/publish/*.pkg
               
   release-ios:
     runs-on: macos-11
@@ -171,10 +171,10 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}        
               
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x 
+          dotnet-version: 9.0.x 
                 
       - name: Install MAUI Workload
         run: dotnet workload install maui --ignore-failed-sources
@@ -190,10 +190,10 @@ jobs:
          isWindows: false
       
       - name: Build iOS
-        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net8.0-ios --no-restore /p:buildForSimulator=True /p:packageApp=True /p:ArchiveOnBuild=False
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net9.0-ios --no-restore /p:buildForSimulator=True /p:packageApp=True /p:ArchiveOnBuild=False
       
       - name: Upload MacCatalyst Artifact
         uses: actions/upload-artifact@v3
         with:
           name: iOS-ci-build
-          path: TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-x64/**/*.app
+          path: TransactionMobile.Maui/bin/Release/net9.0-ios/iossimulator-x64/**/*.app

--- a/.github/workflows/ios_e2e_tests.yml
+++ b/.github/workflows/ios_e2e_tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 🔧 Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: 📦 Install Appium + XCUITest driver
         run: |
@@ -61,7 +61,7 @@ jobs:
         run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
 
       - name: Build Code
-        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-ios -c Release --no-restore
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net9.0-ios -c Release --no-restore
 
       - name: Run iOS Navigation Tests
         run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=iOSPRTest)&(Category=iOS)" --no-restore

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 🔧 Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: 📦 Install Appium + XCUITest driver
         run: |
@@ -61,7 +61,7 @@ jobs:
         run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
 
       - name: Build Code
-        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-ios -c Release --no-restore
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net9.0-ios -c Release --no-restore
 
       - name: Run iOS Navigation Tests
         run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: Install KVM and Android SDK (x86)
         run: |
@@ -54,7 +54,7 @@ jobs:
           dotnet workload install maui-android
 
       - name: Build Code
-        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json -f net8.0-android -c Release #--no-restore
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json -f net9.0-android -c Release #--no-restore
 
       - name: Run unit tests
         run: dotnet test TransactionMobile.Maui.BusinessLogic.Tests/TransactionMobile.Maui.BusinessLogic.Tests.csproj --configuration Release

--- a/.github/workflows/windows_e2e_tests.yml
+++ b/.github/workflows/windows_e2e_tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
      
       - name: Install MAUI workloads
         run: |
@@ -44,7 +44,7 @@ jobs:
         run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
 
       - name: Build Code
-        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-android -c Release --no-restore
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net9.0-android -c Release --no-restore
 
       - name: Decrypt PFX File
         run: |
@@ -56,13 +56,13 @@ jobs:
 
       - name: Publish App
         run: |
-         dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net8.0-windows10.0.19041.0 /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="${{ secrets.WINDOWSSIGNINGCERTTHUMBPRINT }}"      
+         dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net9.0-windows10.0.19041.0 /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="${{ secrets.WINDOWSSIGNINGCERTTHUMBPRINT }}"      
       
       - name: Install App
         shell: powershell
         run: |         
          Import-Module Appx 
-         .\TransactionMobile.Maui/bin/Release/net8.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile.Maui_1.0.0.0_Test/Install.ps1 -Force
+         .\TransactionMobile.Maui/bin/Release/net9.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile.Maui_1.0.0.0_Test/Install.ps1 -Force
 
       - name: Run Windows End To End  Tests
         env:

--- a/.github/workflows/windows_navigation_tests.yml
+++ b/.github/workflows/windows_navigation_tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
      
       - name: Install MAUI workloads
         run: |
@@ -39,7 +39,7 @@ jobs:
         run: dotnet restore TransactionMobile.Maui.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
 
       - name: Build Code
-        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net8.0-android -c Release --no-restore
+        run: dotnet build TransactionMobile.Maui/TransactionMobile.Maui.csproj  -f net9.0-android -c Release --no-restore
 
       - name: Decrypt PFX File
         run: |
@@ -51,13 +51,13 @@ jobs:
 
       - name: Publish App
         run: |
-         dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net8.0-windows10.0.19041.0 /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="${{ secrets.WINDOWSSIGNINGCERTTHUMBPRINT }}"      
+         dotnet publish TransactionMobile.Maui/TransactionMobile.Maui.csproj -c Release -f net9.0-windows10.0.19041.0 /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="${{ secrets.WINDOWSSIGNINGCERTTHUMBPRINT }}"      
       
       - name: Install App
         shell: powershell
         run: |         
          Import-Module Appx 
-         .\TransactionMobile.Maui/bin/Release/net8.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile.Maui_1.0.0.0_Test/Install.ps1 -Force
+         .\TransactionMobile.Maui/bin/Release/net9.0-windows10.0.19041.0/win10-x64/AppPackages/TransactionMobile.Maui_1.0.0.0_Test/Install.ps1 -Force
 
       - name: Run Windows Navigation Tests
         run: dotnet test TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj --filter "(Category=PRNavTest)&(Category=Windows)" --no-restore

--- a/TransactionMobile.Maui.BusinessLogic.Tests/TransactionMobile.Maui.BusinessLogic.Tests.csproj
+++ b/TransactionMobile.Maui.BusinessLogic.Tests/TransactionMobile.Maui.BusinessLogic.Tests.csproj
@@ -1,75 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<!--<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-		<TargetFrameworks>net8.0-android;net8.0-windows10.0.19041.0</TargetFrameworks>
-	</PropertyGroup>
-
-	--><!-- macOS-only: Android + iOS + MacCatalyst --><!--
-	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">
-		<RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
-	</PropertyGroup>-->
-
 	<PropertyGroup>
-	  <TargetFrameworks>net8.0;</TargetFrameworks>
+	  <TargetFrameworks>net9.0;</TargetFrameworks>
 	  <DebugType>None</DebugType>
   </PropertyGroup>
 
-  <!--<ItemGroup>
-    <Compile Remove="ViewModelTests\**" />
-    <EmbeddedResource Remove="ViewModelTests\**" />
-    <MauiCss Remove="ViewModelTests\**" />
-    <MauiXaml Remove="ViewModelTests\**" />
-    <None Remove="ViewModelTests\**" />
-  </ItemGroup>
   <ItemGroup>
-    <Compile Remove="HomePageViewModelTests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ViewModelTests\ExtendedBaseViewModelTests.cs" />
-    <Compile Include="ViewModelTests\HomePageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\LoginPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\MyAccount\MyAccountAddressPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\MyAccount\MyAccountContactPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\MyAccount\MyAccountDetailsPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\MyAccount\MyAccountPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Reports\ReportsPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Support\SupportPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Support\ViewLogsPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\Admin\AdminPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\BillPayment\BillPaymentFailedPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\BillPayment\BillPaymentGetAccountPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\BillPayment\BillPaymentGetMeterPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\BillPayment\BillPaymentPayBillPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\BillPayment\BillPaymentSelectOperatorPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\BillPayment\BillPaymentSelectProductPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\BillPayment\BillPaymentSuccessPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\MobileTopup\MobileTopupFailedPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\MobileTopup\MobileTopupPerformTopupPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\MobileTopup\MobileTopupSelectOperatorPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\MobileTopup\MobileTopupSelectProductPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\MobileTopup\MobileTopupSuccessPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\TransactionsPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\Voucher\VoucherIssueFailedPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\Voucher\VoucherIssueSelectProductPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\Voucher\VoucherIssueSuccessPageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\Voucher\VoucherPerformIssuePageViewModelTests.cs" />
-    <Compile Include="ViewModelTests\Transactions\Voucher\VoucherSelectOperatorPageViewModelTests.cs" />
-  </ItemGroup>-->
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.14" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="SQLite" Version="3.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/TransactionMobile.Maui.BusinessLogic/TransactionMobile.Maui.BusinessLogic.csproj
+++ b/TransactionMobile.Maui.BusinessLogic/TransactionMobile.Maui.BusinessLogic.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-		<TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-		<TargetFrameworks>net8.0;net8.0-android;net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android;net9.0-windows10.0.19041.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<!-- macOS-only: Android + iOS + MacCatalyst -->
 	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-maccatalyst'">
 		<RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
 	</PropertyGroup>
 	
@@ -31,16 +31,16 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="$(TargetFramework) == 'net8.0'">
+	<PropertyGroup Condition="$(TargetFramework) == 'net9.0'">
 		<DefineConstants>$(DefineConstants);NET8_TARGET</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ClientProxyBase" Version="2025.5.4" />
-		<PackageReference Include="Shared.Results" Version="2025.5.4" />
+		<PackageReference Include="ClientProxyBase" Version="2025.6.2" />
+		<PackageReference Include="Shared.Results" Version="2025.6.2" />
 		<PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc2" />
-		<PackageReference Include="MediatR" Version="12.4.1" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+		<PackageReference Include="MediatR" Version="12.5.0" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
 		<PackageReference Include="SecurityService.Client" Version="2025.5.1" />
@@ -54,38 +54,43 @@
 		<PackageReference Include="MetroLog.Maui" Version="2.1.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' != 'net8.0-ios'">
+	<ItemGroup Condition="'$(TargetFramework)' != 'net9.0-ios'">
 		<PackageReference Include="Microsoft.AppCenter" Version="5.0.7" />
 		<PackageReference Include="Microsoft.AppCenter.Distribute" Version="5.0.7" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
 		<PackageReference Include="Microcharts.Maui">
 			<Version>1.0.0</Version>
 		</PackageReference>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
 		<PackageReference Include="Microcharts.Maui">
 			<Version>1.0.0</Version>
 		</PackageReference>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-maccatalyst'">
 		<PackageReference Include="Microcharts.Maui">
 			<Version>1.0.0</Version>
 		</PackageReference>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows10.0.19041.0'">
 		<PackageReference Include="Microcharts.Maui">
 			<Version>1.0.0</Version>
 		</PackageReference>
 	</ItemGroup>
 
 
-	<ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+	<ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
 		<PackageReference Update="Microsoft.Maui.Controls" Version="8.0.14" />
 		<PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.14" />
+	</ItemGroup>
+
+
+	<ItemGroup>
+	  <PackageReference Update="Microsoft.Maui.Controls" Version="9.0.70" />
 	</ItemGroup>
 </Project>

--- a/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
+++ b/TransactionMobile.Maui.UiTests/Drivers/AppiumDriver.cs
@@ -77,7 +77,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
 
         private static void SetupiOSDriver(AppiumLocalService appiumService) {
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-arm64/");
+            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net9.0-ios/iossimulator-arm64/");
             var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
             
             var caps = new AppiumOptions();
@@ -89,64 +89,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             caps.AddAdditionalAppiumOption("fullReset", true);
             caps.AddAdditionalAppiumOption("noReset", false);
             caps.AddAdditionalAppiumOption("useNewWDA", true);
-
-            //var driverOptions = new AppiumOptions();
-            //driverOptions.AutomationName = "XCUITest";
-            ////driverOptions.PlatformName = "iOS";
-            ////driverOptions.PlatformVersion = "17.4";
-            ////driverOptions.DeviceName = "iPhone 11";
-            //driverOptions.AutomationName = "XCUITest";
-            //driverOptions.PlatformName = "iOS";
-            //driverOptions.PlatformVersion = "17.2";
-            //driverOptions.AddAdditionalAppiumOption("udid", Environment.GetEnvironmentVariable("UDID")); // Corrected capability.
-
-            //String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            //String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-arm64/");
-            //var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
-            //driverOptions.App = apkPath;
-            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
-            //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
-            //driverOptions.AddAdditionalAppiumOption("shouldWaitForQuiescence", false);
-            //driverOptions.AddAdditionalAppiumOption("showXcodeLog", true);
-            ////driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
-            ////driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
-            ////driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 60000);
-            ////driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 120000);
-            ////driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 120000);
-            ////driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
-            ////driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
-            ////driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 4);
-            //driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            //driverOptions.AddAdditionalAppiumOption("skipServerInstallation", true);
-            //driverOptions.AddAdditionalAppiumOption("skipProvisioningDeviceDetection", true);
-            //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", Environment.GetEnvironmentVariable("WDA_PATH"));
-            //driverOptions.AddAdditionalAppiumOption("updatedWDABundleId", "WebDriverAgent/build");
-            // Tell Appium to use the prebuilt WDA
-            //driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            //driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
-            //driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true);
-
-            //driverOptions.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/work/WebDriverAgent/build/Build/Products/Debug-iphonesimulator");
-            //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100);
-
-
-            //// Avoid unnecessary WDA rebuild attempts and add resilience
-            //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
-            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 3);
-            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
-
-            //// (Optional but often helpful)
-            //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
-            //driverOptions.AddAdditionalAppiumOption("startIWDP", true); // if you want to inspect webviews
-            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, false);
-            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NoReset, true);
-            //driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100); // optional, but helpful
-            //driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true); // avoids extra processes
-            //driverOptions.AddAdditionalAppiumOption("showXcodeLog", true); // shows build errors in logs
-            //driverOptions.AddAdditionalAppiumOption("bundleId", "com.appium.WebDriverAgentRunner"); // match WDA bundle ID
-
-
+            
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, caps, TimeSpan.FromMinutes(10));
         }
 
@@ -167,7 +110,7 @@ namespace TransactionMobile.Maui.UiTests.Drivers
             driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
 
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-android/");
+            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net9.0-android/");
 
             var apkPath = Path.Combine(binariesFolder, "com.transactionprocessing.pos-Signed.apk");
             var fileinfo = new FileInfo(apkPath);

--- a/TransactionMobile.Maui.UiTests/Features/EndToEndTests.feature.cs
+++ b/TransactionMobile.Maui.UiTests/Features/EndToEndTests.feature.cs
@@ -10,15 +10,13 @@
 // ------------------------------------------------------------------------------
 #region Designer generated code
 #pragma warning disable
+using Reqnroll;
 namespace TransactionMobile.Maui.UiTests.Features
 {
-    using Reqnroll;
-    using System;
-    using System.Linq;
     
     
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "2.0.0.0")]
-    [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "2.0.0.0")]
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("EndToEndTests")]
     [NUnit.Framework.FixtureLifeCycleAttribute(NUnit.Framework.LifeCycle.InstancePerTestCase)]
@@ -45,41 +43,63 @@ namespace TransactionMobile.Maui.UiTests.Features
                 "shared",
                 "transactions"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "EndToEndTests", null, global::Reqnroll.ProgrammingLanguage.CSharp, featureTags);
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features", "EndToEndTests", null, global::Reqnroll.ProgrammingLanguage.CSharp, featureTags);
         
 #line 1 "EndToEndTests.feature"
 #line hidden
         
         [NUnit.Framework.OneTimeSetUpAttribute()]
-        public static async System.Threading.Tasks.Task FeatureSetupAsync()
+        public static async global::System.Threading.Tasks.Task FeatureSetupAsync()
         {
         }
         
         [NUnit.Framework.OneTimeTearDownAttribute()]
-        public static async System.Threading.Tasks.Task FeatureTearDownAsync()
+        public static async global::System.Threading.Tasks.Task FeatureTearDownAsync()
         {
         }
         
         [NUnit.Framework.SetUpAttribute()]
-        public async System.Threading.Tasks.Task TestInitializeAsync()
+        public async global::System.Threading.Tasks.Task TestInitializeAsync()
         {
             testRunner = global::Reqnroll.TestRunnerManager.GetTestRunnerForAssembly(featureHint: featureInfo);
-            if (((testRunner.FeatureContext != null) 
-                        && (testRunner.FeatureContext.FeatureInfo.Equals(featureInfo) == false)))
+            try
             {
-                await testRunner.OnFeatureEndAsync();
+                if (((testRunner.FeatureContext != null) 
+                            && (testRunner.FeatureContext.FeatureInfo.Equals(featureInfo) == false)))
+                {
+                    await testRunner.OnFeatureEndAsync();
+                }
             }
-            if ((testRunner.FeatureContext == null))
+            finally
             {
-                await testRunner.OnFeatureStartAsync(featureInfo);
+                if (((testRunner.FeatureContext != null) 
+                            && testRunner.FeatureContext.BeforeFeatureHookFailed))
+                {
+                    throw new global::Reqnroll.ReqnrollException("Scenario skipped because of previous before feature hook error");
+                }
+                if ((testRunner.FeatureContext == null))
+                {
+                    await testRunner.OnFeatureStartAsync(featureInfo);
+                }
             }
         }
         
         [NUnit.Framework.TearDownAttribute()]
-        public async System.Threading.Tasks.Task TestTearDownAsync()
+        public async global::System.Threading.Tasks.Task TestTearDownAsync()
         {
-            await testRunner.OnScenarioEndAsync();
-            global::Reqnroll.TestRunnerManager.ReleaseTestRunner(testRunner);
+            if ((testRunner == null))
+            {
+                return;
+            }
+            try
+            {
+                await testRunner.OnScenarioEndAsync();
+            }
+            finally
+            {
+                global::Reqnroll.TestRunnerManager.ReleaseTestRunner(testRunner);
+                testRunner = null;
+            }
         }
         
         public void ScenarioInitialize(global::Reqnroll.ScenarioInfo scenarioInfo)
@@ -88,17 +108,17 @@ namespace TransactionMobile.Maui.UiTests.Features
             testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<NUnit.Framework.TestContext>(NUnit.Framework.TestContext.CurrentContext);
         }
         
-        public async System.Threading.Tasks.Task ScenarioStartAsync()
+        public async global::System.Threading.Tasks.Task ScenarioStartAsync()
         {
             await testRunner.OnScenarioStartAsync();
         }
         
-        public async System.Threading.Tasks.Task ScenarioCleanupAsync()
+        public async global::System.Threading.Tasks.Task ScenarioCleanupAsync()
         {
             await testRunner.CollectScenarioErrorsAsync();
         }
         
-        public virtual async System.Threading.Tasks.Task FeatureBackgroundAsync()
+        public virtual async global::System.Threading.Tasks.Task FeatureBackgroundAsync()
         {
 #line 4
 #line hidden
@@ -510,11 +530,11 @@ namespace TransactionMobile.Maui.UiTests.Features
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("EndToEnd")]
         [NUnit.Framework.CategoryAttribute("PRTest")]
-        public async System.Threading.Tasks.Task EndToEnd()
+        public async global::System.Threading.Tasks.Task EndToEnd()
         {
             string[] tagsOfScenario = new string[] {
                     "PRTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("EndToEnd", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 119
 this.ScenarioInitialize(scenarioInfo);

--- a/TransactionMobile.Maui.UiTests/Features/HardwarePageNavigation.feature.cs
+++ b/TransactionMobile.Maui.UiTests/Features/HardwarePageNavigation.feature.cs
@@ -10,15 +10,13 @@
 // ------------------------------------------------------------------------------
 #region Designer generated code
 #pragma warning disable
+using Reqnroll;
 namespace TransactionMobile.Maui.UiTests.Features
 {
-    using Reqnroll;
-    using System;
-    using System.Linq;
     
     
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "2.0.0.0")]
-    [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "2.0.0.0")]
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("HardwarePageNavigation")]
     [NUnit.Framework.FixtureLifeCycleAttribute(NUnit.Framework.LifeCycle.InstancePerTestCase)]
@@ -47,41 +45,63 @@ namespace TransactionMobile.Maui.UiTests.Features
                 "base",
                 "reports"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "HardwarePageNavigation", null, global::Reqnroll.ProgrammingLanguage.CSharp, featureTags);
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features", "HardwarePageNavigation", null, global::Reqnroll.ProgrammingLanguage.CSharp, featureTags);
         
 #line 1 "HardwarePageNavigation.feature"
 #line hidden
         
         [NUnit.Framework.OneTimeSetUpAttribute()]
-        public static async System.Threading.Tasks.Task FeatureSetupAsync()
+        public static async global::System.Threading.Tasks.Task FeatureSetupAsync()
         {
         }
         
         [NUnit.Framework.OneTimeTearDownAttribute()]
-        public static async System.Threading.Tasks.Task FeatureTearDownAsync()
+        public static async global::System.Threading.Tasks.Task FeatureTearDownAsync()
         {
         }
         
         [NUnit.Framework.SetUpAttribute()]
-        public async System.Threading.Tasks.Task TestInitializeAsync()
+        public async global::System.Threading.Tasks.Task TestInitializeAsync()
         {
             testRunner = global::Reqnroll.TestRunnerManager.GetTestRunnerForAssembly(featureHint: featureInfo);
-            if (((testRunner.FeatureContext != null) 
-                        && (testRunner.FeatureContext.FeatureInfo.Equals(featureInfo) == false)))
+            try
             {
-                await testRunner.OnFeatureEndAsync();
+                if (((testRunner.FeatureContext != null) 
+                            && (testRunner.FeatureContext.FeatureInfo.Equals(featureInfo) == false)))
+                {
+                    await testRunner.OnFeatureEndAsync();
+                }
             }
-            if ((testRunner.FeatureContext == null))
+            finally
             {
-                await testRunner.OnFeatureStartAsync(featureInfo);
+                if (((testRunner.FeatureContext != null) 
+                            && testRunner.FeatureContext.BeforeFeatureHookFailed))
+                {
+                    throw new global::Reqnroll.ReqnrollException("Scenario skipped because of previous before feature hook error");
+                }
+                if ((testRunner.FeatureContext == null))
+                {
+                    await testRunner.OnFeatureStartAsync(featureInfo);
+                }
             }
         }
         
         [NUnit.Framework.TearDownAttribute()]
-        public async System.Threading.Tasks.Task TestTearDownAsync()
+        public async global::System.Threading.Tasks.Task TestTearDownAsync()
         {
-            await testRunner.OnScenarioEndAsync();
-            global::Reqnroll.TestRunnerManager.ReleaseTestRunner(testRunner);
+            if ((testRunner == null))
+            {
+                return;
+            }
+            try
+            {
+                await testRunner.OnScenarioEndAsync();
+            }
+            finally
+            {
+                global::Reqnroll.TestRunnerManager.ReleaseTestRunner(testRunner);
+                testRunner = null;
+            }
         }
         
         public void ScenarioInitialize(global::Reqnroll.ScenarioInfo scenarioInfo)
@@ -90,12 +110,12 @@ namespace TransactionMobile.Maui.UiTests.Features
             testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<NUnit.Framework.TestContext>(NUnit.Framework.TestContext.CurrentContext);
         }
         
-        public async System.Threading.Tasks.Task ScenarioStartAsync()
+        public async global::System.Threading.Tasks.Task ScenarioStartAsync()
         {
             await testRunner.OnScenarioStartAsync();
         }
         
-        public async System.Threading.Tasks.Task ScenarioCleanupAsync()
+        public async global::System.Threading.Tasks.Task ScenarioCleanupAsync()
         {
             await testRunner.CollectScenarioErrorsAsync();
         }
@@ -103,11 +123,11 @@ namespace TransactionMobile.Maui.UiTests.Features
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Back Button from Login Screen")]
         [NUnit.Framework.CategoryAttribute("PRNavTest")]
-        public async System.Threading.Tasks.Task BackButtonFromLoginScreen()
+        public async global::System.Threading.Tasks.Task BackButtonFromLoginScreen()
         {
             string[] tagsOfScenario = new string[] {
                     "PRNavTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Back Button from Login Screen", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 5
 this.ScenarioInitialize(scenarioInfo);
@@ -135,11 +155,11 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Device Back Button from Home Page Screen")]
         [NUnit.Framework.CategoryAttribute("PRHWNavTest")]
-        public async System.Threading.Tasks.Task DeviceBackButtonFromHomePageScreen()
+        public async global::System.Threading.Tasks.Task DeviceBackButtonFromHomePageScreen()
         {
             string[] tagsOfScenario = new string[] {
                     "PRHWNavTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Device Back Button from Home Page Screen", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 12
 this.ScenarioInitialize(scenarioInfo);
@@ -200,11 +220,11 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Back Button from Transaction Page Screen")]
         [NUnit.Framework.CategoryAttribute("PRHWNavTest")]
-        public async System.Threading.Tasks.Task BackButtonFromTransactionPageScreen()
+        public async global::System.Threading.Tasks.Task BackButtonFromTransactionPageScreen()
         {
             string[] tagsOfScenario = new string[] {
                     "PRHWNavTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Back Button from Transaction Page Screen", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 30
 this.ScenarioInitialize(scenarioInfo);
@@ -265,11 +285,11 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Back Button from Reports Page Screen")]
         [NUnit.Framework.CategoryAttribute("PRHWNavTest")]
-        public async System.Threading.Tasks.Task BackButtonFromReportsPageScreen()
+        public async global::System.Threading.Tasks.Task BackButtonFromReportsPageScreen()
         {
             string[] tagsOfScenario = new string[] {
                     "PRHWNavTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Back Button from Reports Page Screen", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 48
 this.ScenarioInitialize(scenarioInfo);

--- a/TransactionMobile.Maui.UiTests/Features/PageNavigation.feature.cs
+++ b/TransactionMobile.Maui.UiTests/Features/PageNavigation.feature.cs
@@ -10,15 +10,13 @@
 // ------------------------------------------------------------------------------
 #region Designer generated code
 #pragma warning disable
+using Reqnroll;
 namespace TransactionMobile.Maui.UiTests.Features
 {
-    using Reqnroll;
-    using System;
-    using System.Linq;
     
     
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "2.0.0.0")]
-    [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "2.0.0.0")]
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("PageNavigation")]
     [NUnit.Framework.FixtureLifeCycleAttribute(NUnit.Framework.LifeCycle.InstancePerTestCase)]
@@ -49,41 +47,63 @@ namespace TransactionMobile.Maui.UiTests.Features
                 "reports",
                 "support"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "PageNavigation", null, global::Reqnroll.ProgrammingLanguage.CSharp, featureTags);
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features", "PageNavigation", null, global::Reqnroll.ProgrammingLanguage.CSharp, featureTags);
         
 #line 1 "PageNavigation.feature"
 #line hidden
         
         [NUnit.Framework.OneTimeSetUpAttribute()]
-        public static async System.Threading.Tasks.Task FeatureSetupAsync()
+        public static async global::System.Threading.Tasks.Task FeatureSetupAsync()
         {
         }
         
         [NUnit.Framework.OneTimeTearDownAttribute()]
-        public static async System.Threading.Tasks.Task FeatureTearDownAsync()
+        public static async global::System.Threading.Tasks.Task FeatureTearDownAsync()
         {
         }
         
         [NUnit.Framework.SetUpAttribute()]
-        public async System.Threading.Tasks.Task TestInitializeAsync()
+        public async global::System.Threading.Tasks.Task TestInitializeAsync()
         {
             testRunner = global::Reqnroll.TestRunnerManager.GetTestRunnerForAssembly(featureHint: featureInfo);
-            if (((testRunner.FeatureContext != null) 
-                        && (testRunner.FeatureContext.FeatureInfo.Equals(featureInfo) == false)))
+            try
             {
-                await testRunner.OnFeatureEndAsync();
+                if (((testRunner.FeatureContext != null) 
+                            && (testRunner.FeatureContext.FeatureInfo.Equals(featureInfo) == false)))
+                {
+                    await testRunner.OnFeatureEndAsync();
+                }
             }
-            if ((testRunner.FeatureContext == null))
+            finally
             {
-                await testRunner.OnFeatureStartAsync(featureInfo);
+                if (((testRunner.FeatureContext != null) 
+                            && testRunner.FeatureContext.BeforeFeatureHookFailed))
+                {
+                    throw new global::Reqnroll.ReqnrollException("Scenario skipped because of previous before feature hook error");
+                }
+                if ((testRunner.FeatureContext == null))
+                {
+                    await testRunner.OnFeatureStartAsync(featureInfo);
+                }
             }
         }
         
         [NUnit.Framework.TearDownAttribute()]
-        public async System.Threading.Tasks.Task TestTearDownAsync()
+        public async global::System.Threading.Tasks.Task TestTearDownAsync()
         {
-            await testRunner.OnScenarioEndAsync();
-            global::Reqnroll.TestRunnerManager.ReleaseTestRunner(testRunner);
+            if ((testRunner == null))
+            {
+                return;
+            }
+            try
+            {
+                await testRunner.OnScenarioEndAsync();
+            }
+            finally
+            {
+                global::Reqnroll.TestRunnerManager.ReleaseTestRunner(testRunner);
+                testRunner = null;
+            }
         }
         
         public void ScenarioInitialize(global::Reqnroll.ScenarioInfo scenarioInfo)
@@ -92,12 +112,12 @@ namespace TransactionMobile.Maui.UiTests.Features
             testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<NUnit.Framework.TestContext>(NUnit.Framework.TestContext.CurrentContext);
         }
         
-        public async System.Threading.Tasks.Task ScenarioStartAsync()
+        public async global::System.Threading.Tasks.Task ScenarioStartAsync()
         {
             await testRunner.OnScenarioStartAsync();
         }
         
-        public async System.Threading.Tasks.Task ScenarioCleanupAsync()
+        public async global::System.Threading.Tasks.Task ScenarioCleanupAsync()
         {
             await testRunner.CollectScenarioErrorsAsync();
         }
@@ -105,11 +125,11 @@ namespace TransactionMobile.Maui.UiTests.Features
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Back Button from Home Page Screen")]
         [NUnit.Framework.CategoryAttribute("PRNavTest")]
-        public async System.Threading.Tasks.Task BackButtonFromHomePageScreen()
+        public async global::System.Threading.Tasks.Task BackButtonFromHomePageScreen()
         {
             string[] tagsOfScenario = new string[] {
                     "PRNavTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Back Button from Home Page Screen", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 6
 this.ScenarioInitialize(scenarioInfo);
@@ -170,11 +190,11 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Back Button from Transaction Page Screen")]
         [NUnit.Framework.CategoryAttribute("PRNavTest")]
-        public async System.Threading.Tasks.Task BackButtonFromTransactionPageScreen()
+        public async global::System.Threading.Tasks.Task BackButtonFromTransactionPageScreen()
         {
             string[] tagsOfScenario = new string[] {
                     "PRNavTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Back Button from Transaction Page Screen", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 24
 this.ScenarioInitialize(scenarioInfo);
@@ -235,11 +255,11 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Back Button from Reports Page Screen")]
         [NUnit.Framework.CategoryAttribute("PRNavTest")]
-        public async System.Threading.Tasks.Task BackButtonFromReportsPageScreen()
+        public async global::System.Threading.Tasks.Task BackButtonFromReportsPageScreen()
         {
             string[] tagsOfScenario = new string[] {
                     "PRNavTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Back Button from Reports Page Screen", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 42
 this.ScenarioInitialize(scenarioInfo);
@@ -300,11 +320,11 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Back Button from Profile Page Screen")]
         [NUnit.Framework.CategoryAttribute("PRNavTest")]
-        public async System.Threading.Tasks.Task BackButtonFromProfilePageScreen()
+        public async global::System.Threading.Tasks.Task BackButtonFromProfilePageScreen()
         {
             string[] tagsOfScenario = new string[] {
                     "PRNavTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Back Button from Profile Page Screen", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 60
 this.ScenarioInitialize(scenarioInfo);
@@ -389,11 +409,11 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Back Button from Support Page Screen")]
         [NUnit.Framework.CategoryAttribute("PRNavTest")]
-        public async System.Threading.Tasks.Task BackButtonFromSupportPageScreen()
+        public async global::System.Threading.Tasks.Task BackButtonFromSupportPageScreen()
         {
             string[] tagsOfScenario = new string[] {
                     "PRNavTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Back Button from Support Page Screen", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 86
 this.ScenarioInitialize(scenarioInfo);

--- a/TransactionMobile.Maui.UiTests/Features/iOSEndToEndTests.feature.cs
+++ b/TransactionMobile.Maui.UiTests/Features/iOSEndToEndTests.feature.cs
@@ -10,15 +10,13 @@
 // ------------------------------------------------------------------------------
 #region Designer generated code
 #pragma warning disable
+using Reqnroll;
 namespace TransactionMobile.Maui.UiTests.Features
 {
-    using Reqnroll;
-    using System;
-    using System.Linq;
     
     
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "2.0.0.0")]
-    [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "2.0.0.0")]
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("iOSEndToEndTests")]
     [NUnit.Framework.FixtureLifeCycleAttribute(NUnit.Framework.LifeCycle.InstancePerTestCase)]
@@ -45,41 +43,63 @@ namespace TransactionMobile.Maui.UiTests.Features
                 "shared",
                 "transactions"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "iOSEndToEndTests", null, global::Reqnroll.ProgrammingLanguage.CSharp, featureTags);
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features", "iOSEndToEndTests", null, global::Reqnroll.ProgrammingLanguage.CSharp, featureTags);
         
 #line 1 "iOSEndToEndTests.feature"
 #line hidden
         
         [NUnit.Framework.OneTimeSetUpAttribute()]
-        public static async System.Threading.Tasks.Task FeatureSetupAsync()
+        public static async global::System.Threading.Tasks.Task FeatureSetupAsync()
         {
         }
         
         [NUnit.Framework.OneTimeTearDownAttribute()]
-        public static async System.Threading.Tasks.Task FeatureTearDownAsync()
+        public static async global::System.Threading.Tasks.Task FeatureTearDownAsync()
         {
         }
         
         [NUnit.Framework.SetUpAttribute()]
-        public async System.Threading.Tasks.Task TestInitializeAsync()
+        public async global::System.Threading.Tasks.Task TestInitializeAsync()
         {
             testRunner = global::Reqnroll.TestRunnerManager.GetTestRunnerForAssembly(featureHint: featureInfo);
-            if (((testRunner.FeatureContext != null) 
-                        && (testRunner.FeatureContext.FeatureInfo.Equals(featureInfo) == false)))
+            try
             {
-                await testRunner.OnFeatureEndAsync();
+                if (((testRunner.FeatureContext != null) 
+                            && (testRunner.FeatureContext.FeatureInfo.Equals(featureInfo) == false)))
+                {
+                    await testRunner.OnFeatureEndAsync();
+                }
             }
-            if ((testRunner.FeatureContext == null))
+            finally
             {
-                await testRunner.OnFeatureStartAsync(featureInfo);
+                if (((testRunner.FeatureContext != null) 
+                            && testRunner.FeatureContext.BeforeFeatureHookFailed))
+                {
+                    throw new global::Reqnroll.ReqnrollException("Scenario skipped because of previous before feature hook error");
+                }
+                if ((testRunner.FeatureContext == null))
+                {
+                    await testRunner.OnFeatureStartAsync(featureInfo);
+                }
             }
         }
         
         [NUnit.Framework.TearDownAttribute()]
-        public async System.Threading.Tasks.Task TestTearDownAsync()
+        public async global::System.Threading.Tasks.Task TestTearDownAsync()
         {
-            await testRunner.OnScenarioEndAsync();
-            global::Reqnroll.TestRunnerManager.ReleaseTestRunner(testRunner);
+            if ((testRunner == null))
+            {
+                return;
+            }
+            try
+            {
+                await testRunner.OnScenarioEndAsync();
+            }
+            finally
+            {
+                global::Reqnroll.TestRunnerManager.ReleaseTestRunner(testRunner);
+                testRunner = null;
+            }
         }
         
         public void ScenarioInitialize(global::Reqnroll.ScenarioInfo scenarioInfo)
@@ -88,17 +108,17 @@ namespace TransactionMobile.Maui.UiTests.Features
             testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<NUnit.Framework.TestContext>(NUnit.Framework.TestContext.CurrentContext);
         }
         
-        public async System.Threading.Tasks.Task ScenarioStartAsync()
+        public async global::System.Threading.Tasks.Task ScenarioStartAsync()
         {
             await testRunner.OnScenarioStartAsync();
         }
         
-        public async System.Threading.Tasks.Task ScenarioCleanupAsync()
+        public async global::System.Threading.Tasks.Task ScenarioCleanupAsync()
         {
             await testRunner.CollectScenarioErrorsAsync();
         }
         
-        public virtual async System.Threading.Tasks.Task FeatureBackgroundAsync()
+        public virtual async global::System.Threading.Tasks.Task FeatureBackgroundAsync()
         {
 #line 4
 #line hidden
@@ -107,11 +127,11 @@ namespace TransactionMobile.Maui.UiTests.Features
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("EndToEnd Training Mode")]
         [NUnit.Framework.CategoryAttribute("iOSPRTest")]
-        public async System.Threading.Tasks.Task EndToEndTrainingMode()
+        public async global::System.Threading.Tasks.Task EndToEndTrainingMode()
         {
             string[] tagsOfScenario = new string[] {
                     "iOSPRTest"};
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("EndToEnd Training Mode", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 9
 this.ScenarioInitialize(scenarioInfo);

--- a/TransactionMobile.Maui.UiTests/Steps/SharedAppSteps.cs
+++ b/TransactionMobile.Maui.UiTests/Steps/SharedAppSteps.cs
@@ -39,8 +39,22 @@ namespace TransactionMobile.Maui.UiTests.Steps
 
         [Then(@"The application closes")]
         public void ThenTheApplicationCloses() {
-            AppState state = AppiumDriverWrapper.Driver.GetAppState("com.transactionprocessing.pos");
-            state.ShouldBe(AppState.NotRunning);
+            //AppState state = AppiumDriverWrapper.Driver.GetAppState("com.transactionprocessing.pos");
+            //state.ShouldBe(AppState.NotRunning);
+            AppState appState = (AppState)AppiumDriverWrapper.Driver.ExecuteScript("mobile: queryAppState", new Dictionary<string, object>
+            {
+                ["appId"] = "com.transactionprocessing.pos"
+            });
+            appState.ShouldBe(AppState.NotRunning, "The application should not be running after clicking the back button.");
+        }
+
+        public enum AppState
+        {
+            NotInstalled = 0,
+            NotRunning = 1,
+            RunningInBackgroundSuspended = 2,
+            RunningInBackground = 3,
+            RunningInForeground = 4
         }
 
         [When(@"I click yes")]

--- a/TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj
+++ b/TransactionMobile.Maui.UiTests/TransactionMobile.Maui.UiTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
 	  <IsTestProject>true</IsTestProject>
 	  <DebugType>Full</DebugType>
@@ -9,22 +9,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.14" />
+	  <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.5" />
 	  <PackageReference Include="TransactionProcessor.Database" Version="2025.5.1" />
 	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.5.1" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.14" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-	  <PackageReference Include="Reqnroll.NUnit" Version="2.4.0" />
-	  <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="2.4.0" />
+	  <PackageReference Include="Reqnroll.NUnit" Version="2.4.1" />
+	  <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="2.4.1" />
 	  <PackageReference Include="SecurityService.Client" Version="2025.5.1" />
 	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2025.5.1" />
 	  <PackageReference Include="TransactionProcessor.Client" Version="2025.5.1" />
 	  <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
-	  <PackageReference Include="Appium.WebDriver" Version="7.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2025.5.4" />
+	  <PackageReference Include="Appium.WebDriver" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2025.6.2" />
     <PackageReference Include="Shouldly" Version="4.3.0" />      
-	  <PackageReference Include="NUnit.ConsoleRunner" Version="3.19.2" />
+	  <PackageReference Include="NUnit.ConsoleRunner" Version="3.20.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/TransactionMobile.Maui/TransactionMobile.Maui.csproj
+++ b/TransactionMobile.Maui/TransactionMobile.Maui.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-		<TargetFrameworks>net8.0-android</TargetFrameworks>
+		<TargetFrameworks>net9.0-android</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-		<TargetFrameworks>net8.0-android;net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-windows10.0.19041.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<!-- macOS-only: Android + iOS + MacCatalyst -->
 	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-maccatalyst'">
 		<RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
 	</PropertyGroup>
 
@@ -51,17 +51,17 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="banditoth.MAUI.DeviceId" Version="1.0.0" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.14" />
+		<PackageReference Include="banditoth.MAUI.DeviceId" Version="1.0.2" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="11.2.0" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.70" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.70" />
 		<PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.0-rc2" />
-		<PackageReference Include="MediatR" Version="12.4.1" />
+		<PackageReference Include="MediatR" Version="12.5.0" />
 		<PackageReference Include="MetroLog.Maui" Version="2.1.0" />
 		<PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' != 'net8.0-ios'">
+	<ItemGroup Condition="'$(TargetFramework)' != 'net9.0-ios'">
 		<PackageReference Include="Microsoft.AppCenter" Version="5.0.7" />
 		<PackageReference Include="Microsoft.AppCenter.Distribute" Version="5.0.7" />
 	</ItemGroup>
@@ -265,32 +265,32 @@
     <RuntimeIdentifiers>maccatalyst-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-android|AnyCPU'">
     <AndroidPackageFormat>apk</AndroidPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-ios|AnyCPU'">
     <MtouchLink>None</MtouchLink>
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-ios|AnyCPU'">
     <MtouchLink>SdkOnly</MtouchLink>
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-windows10.0.19041.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-windows10.0.19041.0|AnyCPU'">
     <DefineConstants>$(DefineConstants)TRACE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows10.0.19041.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-windows10.0.19041.0|AnyCPU'">
     <DefineConstants>$(DefineConstants)TRACE</DefineConstants>
     <Optimize>False</Optimize>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-android|AnyCPU'">
     <Optimize>False</Optimize>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-maccatalyst|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-maccatalyst|AnyCPU'">
     <Optimize>False</Optimize>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios15.4|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-ios15.4|AnyCPU'">
     <Optimize>False</Optimize>
   </PropertyGroup>
 


### PR DESCRIPTION
This commit updates the target framework from .NET 8.0 to .NET 9.0 in various YAML configuration files and project files. The .NET version in the setup actions and build commands for Android and iOS end-to-end tests has been changed to '9.0.x'.

Project files for `TransactionMobile.Maui`, `TransactionMobile.Maui.BusinessLogic`, and `TransactionMobile.Maui.UiTests` have been updated to target .NET 9.0, including necessary package reference updates for compatibility.

Additionally, binary paths in the Appium driver setup were modified to align with the new framework version, and several test files were adjusted to ensure proper initialization and handling in the test lifecycle.

These changes enhance performance, introduce new features, and improve support for modern development practices.

Closes #199 