### PR TITLE
Add iOS Navigation Tests workflow to GitHub Actions

### DIFF
--- a/.github/workflows/ios_navigation_tests - Copy.yml
+++ b/.github/workflows/ios_navigation_tests - Copy.yml
@@ -1,0 +1,189 @@
+name: Build and Run iOS Navigation Tests - Self Hosted
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  software_navigation_tests_self_hosted:
+    runs-on: [self-hosted, macOS]
+    #env:
+    #  PLATFORM_VERSION: "18.5"
+    #  DEVICE_NAME: "iPhone 16"
+    #  APP_PATH: "./MyTestApp.app"
+
+    steps:
+      - name: 🧾 Checkout repo
+        uses: actions/checkout@v4
+
+      #- name: 🔧 Set up Node.js
+      #  uses: actions/setup-node@v4
+      #  with:
+      #    node-version: '20'
+
+      #- name: 🔧 Set up .NET
+      #  uses: actions/setup-dotnet@v4
+      #  with:
+      #    dotnet-version: '9.0.x'
+
+      #- name: 📦 Install Appium + XCUITest driver
+      #  run: |
+      #    npm install -g appium
+      #    appium driver install xcuitest
+
+      #- name: 🧹 Clean DerivedData and WDA cache
+      #  run: |
+      #    rm -rf ~/Library/Developer/Xcode/DerivedData
+      #    rm -rf ~/.appium/node_modules/appium-webdriveragent/Build
+
+      #- name: 📱 Create iOS Simulator (if needed)
+      #  run: |
+      #    SIMULATOR_NAME="ci-sim-$RANDOM"
+      #   xcrun simctl create "$SIMULATOR_NAME" "$DEVICE_NAME" "com.apple.CoreSimulator.SimRuntime.iOS-${PLATFORM_VERSION//./-}"
+      #    echo "SIMULATOR_NAME=$SIMULATOR_NAME" >> $GITHUB_ENV
+
+      - name: 🚀 Boot simulator
+        run: |
+           xcrun simctl boot "iPhone 16"
+           SIMULATOR_ID=$(xcrun simctl list | grep 'Booted' | awk -F '[()]' '{print $2}')
+           echo "SIMULATOR_ID=$SIMULATOR_ID"
+           echo "SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
+           
+           # Open the simulator UI so Appium doesn’t force-restart it later
+           open -Fn /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
+    
+           # Wait a bit to ensure the UI is up
+           sleep 5
+
+
+      #- name: List available simulators
+      #  run: |
+      #    xcrun simctl list | grep $SIMULATOR_ID
+
+      #- name: Build, verify, and deploy WebDriverAgent
+      #  run: |
+      #      set -euo pipefail
+
+      #      # Set up vars
+      #      WDA_DIR="/tmp/WebDriverAgent"            
+      #      DERIVED_DATA="/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent"
+      #      #SIMULATOR_UDID="${{ env.UDID }}"
+            # echo "Using simulator $SIMULATOR_ID"
+
+            # # Clone WDA
+            # echo "Cloning WebDriverAgent..."
+            # git clone https://github.com/appium/WebDriverAgent.git "$WDA_DIR"
+
+            # # Build WDA using xcodebuild without signing (safe for CI)
+            # echo "Building WebDriverAgentRunner..."
+            # xcodebuild -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
+            #     -scheme WebDriverAgentRunner \
+            #     -destination "id=$SIMULATOR_ID" \
+            #     -derivedDataPath "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent" \
+            #     CODE_SIGNING_ALLOWED=NO \
+            #     build-for-testing             
+
+            # # Verify build output
+            # echo "Looking for WDA build output..."
+            # WDA_APP=$(find "$DERIVED_DATA" -type d -name "WebDriverAgentRunner-Runner.app" | head -n 1)
+            # if [ -z "$WDA_APP" ]; then
+            #   echo "::error ::Failed to locate built WebDriverAgentRunner-Runner.app"
+            #   exit 1
+            # fi
+            # echo "Found built WDA app at: $WDA_APP"
+
+            # # Launch WDA via xcodebuild test-without-building (required for XCTest runners)
+            # echo "Launching WebDriverAgent test runner on simulator..."
+            # xcodebuild test-without-building \
+            #     -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
+            #     -scheme WebDriverAgentRunner \
+            #     -destination "id=$SIMULATOR_ID" \
+            #     -derivedDataPath "$DERIVED_DATA" \
+            #     IPHONEOS_DEPLOYMENT_TARGET=18.0 \
+            #     GCC_TREAT_WARNINGS_AS_ERRORS=0 \
+            #     COMPILER_INDEX_STORE_ENABLE=NO \
+            #     > /tmp/wda-launch.log 2>&1 &
+
+            # # Wait for WDA to be ready
+            # echo "Waiting for WDA to be available on http://127.0.0.1:8100/status..."
+
+            # for i in {1..30}; do
+            #   if curl --silent --fail http://127.0.0.1:8100/status | grep -q "state"; then
+            #     echo "✅ WDA is up and running."
+            #     exit 0
+            #   fi
+            #   echo "Waiting... ($i)"
+            #   sleep 2
+            # done
+
+            # echo "::error::WDA failed to start within timeout."
+            # exit 1
+
+            # echo "✅ WDA built, verified, installed, and launched successfully."
+
+      - name: 🧪 Start Appium Server
+        run: |
+          nohup appium --log appium.log &
+
+      #- name: Install MAUI Workloads
+      #  run: |
+      #    dotnet workload install ios --ignore-failed-sources
+      #    dotnet workload install maui --ignore-failed-sources
+
+      - name: Restore MAUI App for iOS
+        run: dotnet restore TransactionProcessor.Mobile.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
+
+      #- name: Select Xcode 16.4
+      #  run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
+      #- name: Confirm Xcode version
+      #  run: xcodebuild -version
+
+      #- name: Accept Xcode license
+      #  run: sudo xcodebuild -license accept
+
+      - name: Build Code
+        #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj  -f net9.0-ios -c Release --no-restore
+        #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
+        run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:LinkMode=SdkOnly /p:EnableAssemblyILStripping=true /p:EnableSymbolStrip=true /p:Codesign=false /p:DebugSymbols=false /p:UseInterpreter=true
+
+      # - name: List all files with full path
+      #   run: |
+      #       find /Users/runner/work/TransactionMobile/TransactionMobile/TransactionProcessor.Mobile/bin -type f
+
+      - name: Run iOS Navigation Tests
+        run: |
+            #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
+            dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "Category=PRNavTest" --no-restore
+      #      dotnet tool install --global NUnit.ConsoleRunner.NetCore
+      #      nunit3-console TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "(cat == PRNavTest && cat == iOS)"
+
+      # - name: Run iOS Navigation Tests
+      #   run: |
+      #       # Install NUnit Console Runner tool
+      #       dotnet tool install --global NUnit.ConsoleRunner.NetCore
+
+      #       # Ensure the tool path is available in this step
+      #       export PATH="$PATH:$HOME/.dotnet/tools"
+
+      #       # Optional: clean + build test project if not already built
+      #       dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
+
+      #       # Run the tests filtered by categories
+      #       nunit TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml
+
+      - name: Upload Appium Logs on Failure      
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+            name: ios-software_navigation_tests_appium
+            path: appium.log
+
+      # - name: Upload NUnit Test Results
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: iOS-Test-Results
+      #     path: TestResult-iOS.xml
+
+  

--- a/.github/workflows/ios_navigation_tests - Copy.yml
+++ b/.github/workflows/ios_navigation_tests - Copy.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Build Code
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj  -f net9.0-ios -c Release --no-restore
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
-        run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:LinkMode=SdkOnly /p:EnableAssemblyILStripping=true /p:EnableSymbolStrip=true /p:Codesign=false /p:DebugSymbols=false /p:UseInterpreter=true
+        run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 #/p:LinkMode=SdkOnly /p:EnableAssemblyILStripping=true /p:EnableSymbolStrip=true /p:Codesign=false /p:DebugSymbols=false /p:UseInterpreter=true
 
       # - name: List all files with full path
       #   run: |

--- a/.github/workflows/ios_navigation_tests - Copy.yml
+++ b/.github/workflows/ios_navigation_tests - Copy.yml
@@ -43,18 +43,36 @@ jobs:
       #   xcrun simctl create "$SIMULATOR_NAME" "$DEVICE_NAME" "com.apple.CoreSimulator.SimRuntime.iOS-${PLATFORM_VERSION//./-}"
       #    echo "SIMULATOR_NAME=$SIMULATOR_NAME" >> $GITHUB_ENV
 
+      # - name: 🚀 Boot simulator
+      #   run: |
+      #      xcrun simctl boot "iPhone 16"
+      #      SIMULATOR_ID=$(xcrun simctl list | grep 'Booted' | awk -F '[()]' '{print $2}')
+      #      echo "SIMULATOR_ID=$SIMULATOR_ID"
+      #      echo "SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
+           
+      #      # Open the simulator UI so Appium doesn’t force-restart it later
+      #      open -Fn /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
+    
+      #      # Wait a bit to ensure the UI is up
+      #      sleep 5
       - name: 🚀 Boot simulator
         run: |
-           xcrun simctl boot "iPhone 16"
-           SIMULATOR_ID=$(xcrun simctl list | grep 'Booted' | awk -F '[()]' '{print $2}')
-           echo "SIMULATOR_ID=$SIMULATOR_ID"
-           echo "SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
-           
-           # Open the simulator UI so Appium doesn’t force-restart it later
-           open -Fn /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
-    
-           # Wait a bit to ensure the UI is up
-           sleep 5
+            SIMULATOR_NAME="iPhone 16"
+
+            # Check if the simulator is already booted
+            BOOTED_ID=$(xcrun simctl list devices | grep "$SIMULATOR_NAME" | grep 'Booted' | awk -F '[()]' '{print $2}')
+
+            if [ -n "$BOOTED_ID" ]; then
+              echo "Simulator '$SIMULATOR_NAME' is already booted with ID: $BOOTED_ID"
+              SIMULATOR_ID="$BOOTED_ID"
+            else
+              echo "Booting simulator '$SIMULATOR_NAME'..."
+              SIMULATOR_ID=$(xcrun simctl list devices | grep "$SIMULATOR_NAME" | head -n 1 | awk -F '[()]' '{print $2}' | xargs)
+              xcrun simctl boot "$SIMULATOR_ID"
+            fi
+
+            echo "SIMULATOR_ID=$SIMULATOR_ID"
+            echo "SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
 
 
       #- name: List available simulators

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -70,12 +70,12 @@ jobs:
 
             # Build WDA using xcodebuild without signing (safe for CI)
             echo "Building WebDriverAgentRunner..."
-            xcodebuild build-for-testing
-              -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
+            xcodebuild -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
               -scheme WebDriverAgentRunner \
               -destination "id=$SIMULATOR_ID" \
               CODE_SIGNING_ALLOWED=NO \
               -derivedDataPath /Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent
+              build-for-testing              
 
             # Verify build output
             #echo "Looking for WDA build output..."

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -121,7 +121,8 @@ jobs:
 
       - name: Build Code
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj  -f net9.0-ios -c Release --no-restore
-        run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
+        #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
+        run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:LinkMode=SdkOnly /p:EnableAssemblyILStripping=true /p:EnableSymbolStrip=true /p:Codesign=false /p:DebugSymbols=false /p:UseInterpreter=true
 
       #- name: Build TestCategoryLister
       #  run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   software_navigation_tests:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      PLATFORM_VERSION: "17.5"
-      DEVICE_NAME: "iPhone 14"
+      PLATFORM_VERSION: "18.5"
+      DEVICE_NAME: "iPhone 16"
       APP_PATH: "./MyTestApp.app"
 
     steps:
@@ -134,14 +134,14 @@ jobs:
       - name: Restore MAUI App for iOS
         run: dotnet restore TransactionProcessor.Mobile.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
 
-      #- name: Select Xcode 16.4
-      #  run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Confirm Xcode version
         run: xcodebuild -version
 
-      #- name: Accept Xcode license
-      #  run: sudo xcodebuild -license accept
+      - name: Accept Xcode license
+        run: sudo xcodebuild -license accept
 
       - name: Build Code
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj  -f net9.0-ios -c Release --no-restore

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -82,6 +82,10 @@ jobs:
       #  run: |
       #    dotnet TestCategoryLister/bin/Release/net9.0/TestCategoryLister.dll TransactionProcessor.Mobile.UiTests/bin/Debug/net9.0/TransactionProcessor.Mobile.UiTests.dll
 
+      - name: List all files with full path
+        run: |
+            find /Users/runner/work/TransactionMobile/TransactionMobile/TransactionProcessor.Mobile/bin -type f
+
       - name: Run iOS Navigation Tests
         run: |
             #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -100,6 +100,20 @@ jobs:
               exit 1
             fi
 
+            echo "Waiting for WDA to be available on http://127.0.0.1:8100/status..."
+
+            for i in {1..30}; do
+              if curl --silent --fail http://127.0.0.1:8100/status | grep -q "state"; then
+                echo "✅ WDA is up and running."
+                exit 0
+              fi
+              echo "Waiting... ($i)"
+              sleep 2
+            done
+
+            echo "::error::WDA failed to start within timeout."
+            exit 1
+
             echo "✅ WDA built, verified, installed, and launched successfully."
 
 

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -59,7 +59,7 @@ jobs:
             set -euo pipefail
 
             # Set up vars
-            WDA_DIR="/tmp/WebDriverAgent"
+            WDA_DIR="/tmp/WebDriverAgent"            
             DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData"
             #SIMULATOR_UDID="${{ env.UDID }}"
             echo "Using simulator $SIMULATOR_ID"

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -47,17 +47,60 @@ jobs:
           xcrun simctl create "$SIMULATOR_NAME" "$DEVICE_NAME" "com.apple.CoreSimulator.SimRuntime.iOS-${PLATFORM_VERSION//./-}"
           echo "SIMULATOR_NAME=$SIMULATOR_NAME" >> $GITHUB_ENV
 
-      #- name: 🚀 Boot simulator
-      #  run: |
-      #    xcrun simctl boot "$SIMULATOR_NAME"
-      #    xcrun simctl list | grep Booted
-
       - name: 🚀 Boot simulator
         run: |
            xcrun simctl boot "$SIMULATOR_NAME"
            SIMULATOR_ID=$(xcrun simctl list | grep 'Booted' | awk -F '[()]' '{print $2}')
            echo "SIMULATOR_ID=$SIMULATOR_ID"
            echo "SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
+
+      - name: Build, verify, and deploy WebDriverAgent
+        run: |
+            set -euo pipefail
+
+            # Set up vars
+            WDA_DIR="/tmp/WebDriverAgent"
+            DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData"
+            SIMULATOR_UDID="${{ env.UDID }}"
+            echo "Using simulator $SIMULATOR_UDID"
+
+            # Clone WDA
+            echo "Cloning WebDriverAgent..."
+            git clone https://github.com/appium/WebDriverAgent.git "$WDA_DIR"
+
+            # Build WDA using xcodebuild without signing (safe for CI)
+            echo "Building WebDriverAgentRunner..."
+            xcodebuild -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
+              -scheme WebDriverAgentRunner \
+              -destination "id=$SIMULATOR_UDID" \
+              CODE_SIGNING_ALLOWED=NO \
+              build-for-testing
+
+            # Verify build output
+            echo "Looking for WDA build output..."
+            WDA_APP=$(find "$DERIVED_DATA" -type d -name "WebDriverAgentRunner-Runner.app" | head -n 1)
+            if [ -z "$WDA_APP" ]; then
+              echo "::error ::Failed to locate built WebDriverAgentRunner-Runner.app"
+              exit 1
+            fi
+            echo "Found built WDA app at: $WDA_APP"
+
+            # Install app to simulator
+            echo "Installing WDA app to simulator $SIMULATOR_UDID..."
+            xcrun simctl install "$SIMULATOR_UDID" "$WDA_APP"
+
+            # Launch WDA manually to ensure it's functional
+            echo "Launching WDA app on simulator..."
+            LAUNCH_OUTPUT=$(xcrun simctl launch "$SIMULATOR_UDID" com.facebook.WebDriverAgentRunner.xctrunner || true)
+
+            if echo "$LAUNCH_OUTPUT" | grep -q "error"; then
+              echo "::error ::Failed to launch WebDriverAgent on simulator. Output:"
+              echo "$LAUNCH_OUTPUT"
+              exit 1
+            fi
+
+            echo "✅ WDA built, verified, installed, and launched successfully."
+
 
       - name: Install MAUI Workloads
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Build Code
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj  -f net9.0-ios -c Release --no-restore
-        run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-x64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
+        run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
 
       #- name: Build TestCategoryLister
       #  run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -9,8 +9,8 @@ jobs:
   software_navigation_tests:
     runs-on: macos-15
     env:
-      PLATFORM_VERSION: "18.0"
-      DEVICE_NAME: "iPhone 16"
+      PLATFORM_VERSION: "17.4"
+      DEVICE_NAME: "iPhone 14"
       APP_PATH: "./MyTestApp.app"
 
     steps:
@@ -32,10 +32,10 @@ jobs:
           npm install -g appium
           appium driver install xcuitest
 
-      - name: 🧹 Clean DerivedData and WDA cache
-        run: |
-          rm -rf ~/Library/Developer/Xcode/DerivedData
-          rm -rf ~/.appium/node_modules/appium-webdriveragent/Build
+      #- name: 🧹 Clean DerivedData and WDA cache
+      #  run: |
+      #    rm -rf ~/Library/Developer/Xcode/DerivedData
+      #    rm -rf ~/.appium/node_modules/appium-webdriveragent/Build
 
       - name: 📱 Create iOS Simulator (if needed)
         run: |
@@ -61,66 +61,66 @@ jobs:
         run: |
           xcrun simctl list | grep $SIMULATOR_ID
 
-      - name: Build, verify, and deploy WebDriverAgent
-        run: |
-            set -euo pipefail
+      #- name: Build, verify, and deploy WebDriverAgent
+      #  run: |
+      #      set -euo pipefail
 
-            # Set up vars
-            WDA_DIR="/tmp/WebDriverAgent"            
-            DERIVED_DATA="/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent"
-            #SIMULATOR_UDID="${{ env.UDID }}"
-            echo "Using simulator $SIMULATOR_ID"
+      #      # Set up vars
+      #      WDA_DIR="/tmp/WebDriverAgent"            
+      #      DERIVED_DATA="/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent"
+      #      #SIMULATOR_UDID="${{ env.UDID }}"
+            # echo "Using simulator $SIMULATOR_ID"
 
-            # Clone WDA
-            echo "Cloning WebDriverAgent..."
-            git clone https://github.com/appium/WebDriverAgent.git "$WDA_DIR"
+            # # Clone WDA
+            # echo "Cloning WebDriverAgent..."
+            # git clone https://github.com/appium/WebDriverAgent.git "$WDA_DIR"
 
-            # Build WDA using xcodebuild without signing (safe for CI)
-            echo "Building WebDriverAgentRunner..."
-            xcodebuild -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
-                -scheme WebDriverAgentRunner \
-                -destination "id=$SIMULATOR_ID" \
-                -derivedDataPath "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent" \
-                CODE_SIGNING_ALLOWED=NO \
-                build-for-testing             
+            # # Build WDA using xcodebuild without signing (safe for CI)
+            # echo "Building WebDriverAgentRunner..."
+            # xcodebuild -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
+            #     -scheme WebDriverAgentRunner \
+            #     -destination "id=$SIMULATOR_ID" \
+            #     -derivedDataPath "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent" \
+            #     CODE_SIGNING_ALLOWED=NO \
+            #     build-for-testing             
 
-            # Verify build output
-            echo "Looking for WDA build output..."
-            WDA_APP=$(find "$DERIVED_DATA" -type d -name "WebDriverAgentRunner-Runner.app" | head -n 1)
-            if [ -z "$WDA_APP" ]; then
-              echo "::error ::Failed to locate built WebDriverAgentRunner-Runner.app"
-              exit 1
-            fi
-            echo "Found built WDA app at: $WDA_APP"
+            # # Verify build output
+            # echo "Looking for WDA build output..."
+            # WDA_APP=$(find "$DERIVED_DATA" -type d -name "WebDriverAgentRunner-Runner.app" | head -n 1)
+            # if [ -z "$WDA_APP" ]; then
+            #   echo "::error ::Failed to locate built WebDriverAgentRunner-Runner.app"
+            #   exit 1
+            # fi
+            # echo "Found built WDA app at: $WDA_APP"
 
-            # Launch WDA via xcodebuild test-without-building (required for XCTest runners)
-            echo "Launching WebDriverAgent test runner on simulator..."
-            xcodebuild test-without-building \
-                -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
-                -scheme WebDriverAgentRunner \
-                -destination "id=$SIMULATOR_ID" \
-                -derivedDataPath "$DERIVED_DATA" \
-                IPHONEOS_DEPLOYMENT_TARGET=18.0 \
-                GCC_TREAT_WARNINGS_AS_ERRORS=0 \
-                COMPILER_INDEX_STORE_ENABLE=NO \
-                > /tmp/wda-launch.log 2>&1 &
+            # # Launch WDA via xcodebuild test-without-building (required for XCTest runners)
+            # echo "Launching WebDriverAgent test runner on simulator..."
+            # xcodebuild test-without-building \
+            #     -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
+            #     -scheme WebDriverAgentRunner \
+            #     -destination "id=$SIMULATOR_ID" \
+            #     -derivedDataPath "$DERIVED_DATA" \
+            #     IPHONEOS_DEPLOYMENT_TARGET=18.0 \
+            #     GCC_TREAT_WARNINGS_AS_ERRORS=0 \
+            #     COMPILER_INDEX_STORE_ENABLE=NO \
+            #     > /tmp/wda-launch.log 2>&1 &
 
-            # Wait for WDA to be ready
-            echo "Waiting for WDA to be available on http://127.0.0.1:8100/status..."
+            # # Wait for WDA to be ready
+            # echo "Waiting for WDA to be available on http://127.0.0.1:8100/status..."
 
-            for i in {1..30}; do
-              if curl --silent --fail http://127.0.0.1:8100/status | grep -q "state"; then
-                echo "✅ WDA is up and running."
-                exit 0
-              fi
-              echo "Waiting... ($i)"
-              sleep 2
-            done
+            # for i in {1..30}; do
+            #   if curl --silent --fail http://127.0.0.1:8100/status | grep -q "state"; then
+            #     echo "✅ WDA is up and running."
+            #     exit 0
+            #   fi
+            #   echo "Waiting... ($i)"
+            #   sleep 2
+            # done
 
-            echo "::error::WDA failed to start within timeout."
-            exit 1
+            # echo "::error::WDA failed to start within timeout."
+            # exit 1
 
-            echo "✅ WDA built, verified, installed, and launched successfully."
+            # echo "✅ WDA built, verified, installed, and launched successfully."
 
       - name: 🧪 Start Appium Server
         run: |
@@ -148,18 +148,9 @@ jobs:
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
         run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:LinkMode=SdkOnly /p:EnableAssemblyILStripping=true /p:EnableSymbolStrip=true /p:Codesign=false /p:DebugSymbols=false /p:UseInterpreter=true
 
-      #- name: Build TestCategoryLister
-      #  run: |
-      #    dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
-      #    dotnet build TestCategoryLister/TestCategoryLister.csproj -c Release
-
-      #- name: Run CategoryListerTool on UI Tests
-      #  run: |
-      #    dotnet TestCategoryLister/bin/Release/net9.0/TestCategoryLister.dll TransactionProcessor.Mobile.UiTests/bin/Debug/net9.0/TransactionProcessor.Mobile.UiTests.dll
-
-      - name: List all files with full path
-        run: |
-            find /Users/runner/work/TransactionMobile/TransactionMobile/TransactionProcessor.Mobile/bin -type f
+      # - name: List all files with full path
+      #   run: |
+      #       find /Users/runner/work/TransactionMobile/TransactionMobile/TransactionProcessor.Mobile/bin -type f
 
       - name: Run iOS Navigation Tests
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -60,7 +60,7 @@ jobs:
 
             # Set up vars
             WDA_DIR="/tmp/WebDriverAgent"            
-            DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData"
+            DERIVED_DATA="/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent"
             #SIMULATOR_UDID="${{ env.UDID }}"
             echo "Using simulator $SIMULATOR_ID"
 
@@ -78,13 +78,13 @@ jobs:
               build-for-testing              
 
             # Verify build output
-            #echo "Looking for WDA build output..."
-            #WDA_APP=$(find "$DERIVED_DATA" -type d -name "WebDriverAgentRunner-Runner.app" | head -n 1)
-            #if [ -z "$WDA_APP" ]; then
-            #  echo "::error ::Failed to locate built WebDriverAgentRunner-Runner.app"
-            #  exit 1
-            #fi
-            #echo "Found built WDA app at: $WDA_APP"
+            echo "Looking for WDA build output..."
+            WDA_APP=$(find "$DERIVED_DATA" -type d -name "WebDriverAgentRunner-Runner.app" | head -n 1)
+            if [ -z "$WDA_APP" ]; then
+              echo "::error ::Failed to locate built WebDriverAgentRunner-Runner.app"
+              exit 1
+            fi
+            echo "Found built WDA app at: $WDA_APP"
 
             # Install app to simulator
             echo "Installing WDA app to simulator $SIMULATOR_ID..."

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -70,20 +70,21 @@ jobs:
 
             # Build WDA using xcodebuild without signing (safe for CI)
             echo "Building WebDriverAgentRunner..."
-            xcodebuild -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
+            xcodebuild build-for-testing
+              -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
               -scheme WebDriverAgentRunner \
               -destination "id=$SIMULATOR_ID" \
               CODE_SIGNING_ALLOWED=NO \
-              build-for-testing
+              -derivedDataPath /Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent
 
             # Verify build output
-            echo "Looking for WDA build output..."
-            WDA_APP=$(find "$DERIVED_DATA" -type d -name "WebDriverAgentRunner-Runner.app" | head -n 1)
-            if [ -z "$WDA_APP" ]; then
-              echo "::error ::Failed to locate built WebDriverAgentRunner-Runner.app"
-              exit 1
-            fi
-            echo "Found built WDA app at: $WDA_APP"
+            #echo "Looking for WDA build output..."
+            #WDA_APP=$(find "$DERIVED_DATA" -type d -name "WebDriverAgentRunner-Runner.app" | head -n 1)
+            #if [ -z "$WDA_APP" ]; then
+            #  echo "::error ::Failed to locate built WebDriverAgentRunner-Runner.app"
+            #  exit 1
+            #fi
+            #echo "Found built WDA app at: $WDA_APP"
 
             # Install app to simulator
             echo "Installing WDA app to simulator $SIMULATOR_ID..."

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -82,12 +82,26 @@ jobs:
       #  run: |
       #    dotnet TestCategoryLister/bin/Release/net9.0/TestCategoryLister.dll TransactionProcessor.Mobile.UiTests/bin/Debug/net9.0/TransactionProcessor.Mobile.UiTests.dll
 
-      - name: Run iOS Navigation Tests
-        run: |
+      #- name: Run iOS Navigation Tests
+      #  run: |
             #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
             #dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
+      #      dotnet tool install --global NUnit.ConsoleRunner.NetCore
+      #      nunit3-console TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "(cat == PRNavTest && cat == iOS)"
+
+      - name: Run iOS Navigation Tests
+        run: |
+            # Install NUnit Console Runner tool
             dotnet tool install --global NUnit.ConsoleRunner.NetCore
-            nunit3-console TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "(cat == PRNavTest && cat == iOS)"
+
+            # Ensure the tool path is available in this step
+            export PATH="$PATH:$HOME/.dotnet/tools"
+
+            # Optional: clean + build test project if not already built
+            dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
+
+            # Run the tests filtered by categories
+            nunit3-console TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml
 
       - name: Upload Appium Logs on Failure      
         if: failure()
@@ -95,5 +109,11 @@ jobs:
         with:
             name: ios-software_navigation_tests_appium
             path: appium.log
+
+      - name: Upload NUnit Test Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: iOS-Test-Results
+          path: TestResult-iOS.xml
 
   

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Build Code
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj  -f net9.0-ios -c Release --no-restore
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
-        run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 /p:LinkMode=SdkOnly /p:EnableAssemblyILStripping=true /p:EnableSymbolStrip=true /p:Codesign=false /p:DebugSymbols=false /p:UseInterpreter=true
+        run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-arm64 #/p:LinkMode=SdkOnly /p:EnableAssemblyILStripping=true /p:EnableSymbolStrip=true /p:Codesign=false /p:DebugSymbols=false /p:UseInterpreter=true
 
       # - name: List all files with full path
       #   run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -101,7 +101,7 @@ jobs:
             dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
 
             # Run the tests filtered by categories
-            nunit3-console TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml
+            nunit3 TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml
 
       - name: Upload Appium Logs on Failure      
         if: failure()

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -47,10 +47,17 @@ jobs:
           xcrun simctl create "$SIMULATOR_NAME" "$DEVICE_NAME" "com.apple.CoreSimulator.SimRuntime.iOS-${PLATFORM_VERSION//./-}"
           echo "SIMULATOR_NAME=$SIMULATOR_NAME" >> $GITHUB_ENV
 
+      #- name: 🚀 Boot simulator
+      #  run: |
+      #    xcrun simctl boot "$SIMULATOR_NAME"
+      #    xcrun simctl list | grep Booted
+
       - name: 🚀 Boot simulator
         run: |
-          xcrun simctl boot "$SIMULATOR_NAME"
-          xcrun simctl list | grep Booted
+           xcrun simctl boot "$SIMULATOR_NAME"
+           SIMULATOR_ID=$(xcrun simctl list | grep 'Booted' | awk -F '[()]' '{print $2}')
+           echo "SIMULATOR_ID=$SIMULATOR_ID"
+           echo "SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
 
       - name: Install MAUI Workloads
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Run CategoryListerTool on UI Tests
         run: |
-          dotnet TestCategoryLister/TestCategoryLister/bin/Release/net9.0/TestCategoryLister.dll TransactionProcessor.Mobile.UiTests/bin/Debug/net9.0/TransactionProcessor.Mobile.UiTests.dll
+          dotnet TestCategoryLister/bin/Release/net9.0/TestCategoryLister.dll TransactionProcessor.Mobile.UiTests/bin/Debug/net9.0/TransactionProcessor.Mobile.UiTests.dll
 
       - name: Run iOS Navigation Tests
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -71,11 +71,11 @@ jobs:
             # Build WDA using xcodebuild without signing (safe for CI)
             echo "Building WebDriverAgentRunner..."
             xcodebuild -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
-              -scheme WebDriverAgentRunner \
-              -destination "id=$SIMULATOR_ID" \
-              CODE_SIGNING_ALLOWED=NO \
-              -derivedDataPath /Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent
-              build-for-testing              
+                -scheme WebDriverAgentRunner \
+                -destination "id=$SIMULATOR_ID" \
+                -derivedDataPath "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent" \
+                CODE_SIGNING_ALLOWED=NO \
+                build-for-testing             
 
             # Verify build output
             echo "Looking for WDA build output..."

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -86,20 +86,19 @@ jobs:
             fi
             echo "Found built WDA app at: $WDA_APP"
 
-            # Install app to simulator
-            echo "Installing WDA app to simulator $SIMULATOR_ID..."
-            xcrun simctl install "$SIMULATOR_ID" "$WDA_APP"
+            # Launch WDA via xcodebuild test-without-building (required for XCTest runners)
+            echo "Launching WebDriverAgent test runner on simulator..."
+            xcodebuild test-without-building \
+                -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
+                -scheme WebDriverAgentRunner \
+                -destination "id=$SIMULATOR_ID" \
+                -derivedDataPath "$DERIVED_DATA" \
+                IPHONEOS_DEPLOYMENT_TARGET=18.0 \
+                GCC_TREAT_WARNINGS_AS_ERRORS=0 \
+                COMPILER_INDEX_STORE_ENABLE=NO \
+                > /tmp/wda-launch.log 2>&1 &
 
-            # Launch WDA manually to ensure it's functional
-            echo "Launching WDA app on simulator..."
-            LAUNCH_OUTPUT=$(xcrun simctl launch "$SIMULATOR_ID" com.facebook.WebDriverAgentRunner.xctrunner || true)
-
-            if echo "$LAUNCH_OUTPUT" | grep -q "error"; then
-              echo "::error ::Failed to launch WebDriverAgent on simulator. Output:"
-              echo "$LAUNCH_OUTPUT"
-              exit 1
-            fi
-
+            # Wait for WDA to be ready
             echo "Waiting for WDA to be available on http://127.0.0.1:8100/status..."
 
             for i in {1..30}; do

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -98,7 +98,7 @@ jobs:
             export PATH="$PATH:$HOME/.dotnet/tools"
 
             # Optional: clean + build test project if not already built
-            #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
+            dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
 
             # Run the tests filtered by categories
             nunit TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -101,7 +101,7 @@ jobs:
             #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
 
             # Run the tests filtered by categories
-            nunit3 TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml
+            nunit TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml
 
       - name: Upload Appium Logs on Failure      
         if: failure()

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -74,7 +74,9 @@ jobs:
         run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-x64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
 
       - name: Run iOS Navigation Tests
-        run: dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
+        run: |
+            dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
+            dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
 
       - name: Upload Appium Logs on Failure      
         if: failure()

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -86,6 +86,7 @@ jobs:
         run: |
             #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
             #dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
+            dotnet tool install --global NUnit.ConsoleRunner.NetCore
             nunit3-console TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "(cat == PRNavTest && cat == iOS)"
 
       - name: Upload Appium Logs on Failure      

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -37,10 +37,6 @@ jobs:
           rm -rf ~/Library/Developer/Xcode/DerivedData
           rm -rf ~/.appium/node_modules/appium-webdriveragent/Build
 
-      - name: 🧪 Start Appium Server
-        run: |
-          nohup appium --log appium.log &
-
       - name: 📱 Create iOS Simulator (if needed)
         run: |
           SIMULATOR_NAME="ci-sim-$RANDOM"
@@ -53,6 +49,13 @@ jobs:
            SIMULATOR_ID=$(xcrun simctl list | grep 'Booted' | awk -F '[()]' '{print $2}')
            echo "SIMULATOR_ID=$SIMULATOR_ID"
            echo "SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
+           
+           # Open the simulator UI so Appium doesn’t force-restart it later
+           open -Fn /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
+    
+           # Wait a bit to ensure the UI is up
+           sleep 5
+
 
       - name: List available simulators
         run: |
@@ -119,6 +122,9 @@ jobs:
 
             echo "✅ WDA built, verified, installed, and launched successfully."
 
+      - name: 🧪 Start Appium Server
+        run: |
+          nohup appium --log appium.log &
 
       - name: Install MAUI Workloads
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -73,19 +73,20 @@ jobs:
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj  -f net9.0-ios -c Release --no-restore
         run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-x64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
 
-      - name: Build TestCategoryLister
-        run: |
-          dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
-          dotnet build TestCategoryLister/TestCategoryLister.csproj -c Release
+      #- name: Build TestCategoryLister
+      #  run: |
+      #    dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
+      #    dotnet build TestCategoryLister/TestCategoryLister.csproj -c Release
 
-      - name: Run CategoryListerTool on UI Tests
-        run: |
-          dotnet TestCategoryLister/bin/Release/net9.0/TestCategoryLister.dll TransactionProcessor.Mobile.UiTests/bin/Debug/net9.0/TransactionProcessor.Mobile.UiTests.dll
+      #- name: Run CategoryListerTool on UI Tests
+      #  run: |
+      #    dotnet TestCategoryLister/bin/Release/net9.0/TestCategoryLister.dll TransactionProcessor.Mobile.UiTests/bin/Debug/net9.0/TransactionProcessor.Mobile.UiTests.dll
 
       - name: Run iOS Navigation Tests
         run: |
-            dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
-            dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
+            #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
+            #dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
+            nunit3-console TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "(cat == PRNavTest && cat == iOS)"
 
       - name: Upload Appium Logs on Failure      
         if: failure()

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -54,6 +54,10 @@ jobs:
            echo "SIMULATOR_ID=$SIMULATOR_ID"
            echo "SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
 
+      - name: List available simulators
+        run: |
+          xcrun simctl list | grep $SIMULATOR_ID
+
       - name: Build, verify, and deploy WebDriverAgent
         run: |
             set -euo pipefail

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -98,7 +98,7 @@ jobs:
             export PATH="$PATH:$HOME/.dotnet/tools"
 
             # Optional: clean + build test project if not already built
-            dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
+            #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
 
             # Run the tests filtered by categories
             nunit3 TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build TestCategoryLister
         run: |
           dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
-          dotnet build TestCategoryLister/TestCategoryLister.csproj --configuration Release
+          dotnet build TestCategoryLister/TestCategoryLister.csproj -c Release
 
       - name: Run CategoryListerTool on UI Tests
         run: |

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   software_navigation_tests:
-    runs-on: macos-15
+    runs-on: macos-14
     env:
-      PLATFORM_VERSION: "17.4"
+      PLATFORM_VERSION: "17.5"
       DEVICE_NAME: "iPhone 14"
       APP_PATH: "./MyTestApp.app"
 
@@ -134,14 +134,14 @@ jobs:
       - name: Restore MAUI App for iOS
         run: dotnet restore TransactionProcessor.Mobile.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }} --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
 
-      - name: Select Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+      #- name: Select Xcode 16.4
+      #  run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Confirm Xcode version
         run: xcodebuild -version
 
-      - name: Accept Xcode license
-        run: sudo xcodebuild -license accept
+      #- name: Accept Xcode license
+      #  run: sudo xcodebuild -license accept
 
       - name: Build Code
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj  -f net9.0-ios -c Release --no-restore

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -73,6 +73,15 @@ jobs:
         #run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj  -f net9.0-ios -c Release --no-restore
         run: dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net9.0-ios -r iossimulator-x64 /p:EnableAssemblyILStripping=false /p:EnableSymbolStrip=false /p:LinkMode=None
 
+      - name: Build TestCategoryLister
+        run: |
+          dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
+          dotnet build TestCategoryLister/TestCategoryLister.csproj --configuration Release
+
+      - name: Run CategoryListerTool on UI Tests
+        run: |
+          dotnet TestCategoryLister/TestCategoryLister/bin/Release/net9.0/TestCategoryLister.dll TransactionProcessor.Mobile.UiTests/bin/Debug/net9.0/TransactionProcessor.Mobile.UiTests.dll
+
       - name: Run iOS Navigation Tests
         run: |
             dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -61,7 +61,7 @@ jobs:
             # Set up vars
             WDA_DIR="/tmp/WebDriverAgent"
             DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData"
-            SIMULATOR_UDID="${{ env.UDID }}"
+            #SIMULATOR_UDID="${{ env.UDID }}"
             echo "Using simulator $SIMULATOR_UDID"
 
             # Clone WDA
@@ -72,7 +72,7 @@ jobs:
             echo "Building WebDriverAgentRunner..."
             xcodebuild -project "$WDA_DIR/WebDriverAgent.xcodeproj" \
               -scheme WebDriverAgentRunner \
-              -destination "id=$SIMULATOR_UDID" \
+              -destination "id=$SIMULATOR_ID" \
               CODE_SIGNING_ALLOWED=NO \
               build-for-testing
 
@@ -86,12 +86,12 @@ jobs:
             echo "Found built WDA app at: $WDA_APP"
 
             # Install app to simulator
-            echo "Installing WDA app to simulator $SIMULATOR_UDID..."
-            xcrun simctl install "$SIMULATOR_UDID" "$WDA_APP"
+            echo "Installing WDA app to simulator $SIMULATOR_ID..."
+            xcrun simctl install "$SIMULATOR_ID" "$WDA_APP"
 
             # Launch WDA manually to ensure it's functional
             echo "Launching WDA app on simulator..."
-            LAUNCH_OUTPUT=$(xcrun simctl launch "$SIMULATOR_UDID" com.facebook.WebDriverAgentRunner.xctrunner || true)
+            LAUNCH_OUTPUT=$(xcrun simctl launch "$SIMULATOR_ID" com.facebook.WebDriverAgentRunner.xctrunner || true)
 
             if echo "$LAUNCH_OUTPUT" | grep -q "error"; then
               echo "::error ::Failed to launch WebDriverAgent on simulator. Output:"

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -62,7 +62,7 @@ jobs:
             WDA_DIR="/tmp/WebDriverAgent"
             DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData"
             #SIMULATOR_UDID="${{ env.UDID }}"
-            echo "Using simulator $SIMULATOR_UDID"
+            echo "Using simulator $SIMULATOR_ID"
 
             # Clone WDA
             echo "Cloning WebDriverAgent..."

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -82,26 +82,26 @@ jobs:
       #  run: |
       #    dotnet TestCategoryLister/bin/Release/net9.0/TestCategoryLister.dll TransactionProcessor.Mobile.UiTests/bin/Debug/net9.0/TransactionProcessor.Mobile.UiTests.dll
 
-      #- name: Run iOS Navigation Tests
-      #  run: |
+      - name: Run iOS Navigation Tests
+        run: |
             #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
-            #dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "(Category=PRNavTest)&(Category=iOS)" --no-restore
+            dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "Category=PRNavTest&Category=iOS" --no-restore
       #      dotnet tool install --global NUnit.ConsoleRunner.NetCore
       #      nunit3-console TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "(cat == PRNavTest && cat == iOS)"
 
-      - name: Run iOS Navigation Tests
-        run: |
-            # Install NUnit Console Runner tool
-            dotnet tool install --global NUnit.ConsoleRunner.NetCore
+      # - name: Run iOS Navigation Tests
+      #   run: |
+      #       # Install NUnit Console Runner tool
+      #       dotnet tool install --global NUnit.ConsoleRunner.NetCore
 
-            # Ensure the tool path is available in this step
-            export PATH="$PATH:$HOME/.dotnet/tools"
+      #       # Ensure the tool path is available in this step
+      #       export PATH="$PATH:$HOME/.dotnet/tools"
 
-            # Optional: clean + build test project if not already built
-            dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
+      #       # Optional: clean + build test project if not already built
+      #       dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Release --no-restore
 
-            # Run the tests filtered by categories
-            nunit TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml
+      #       # Run the tests filtered by categories
+      #       nunit TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "cat == PRNavTest && cat == iOS" --labels=All --result=TestResult-iOS.xml
 
       - name: Upload Appium Logs on Failure      
         if: failure()
@@ -110,10 +110,10 @@ jobs:
             name: ios-software_navigation_tests_appium
             path: appium.log
 
-      - name: Upload NUnit Test Results
-        uses: actions/upload-artifact@v4
-        with:
-          name: iOS-Test-Results
-          path: TestResult-iOS.xml
+      # - name: Upload NUnit Test Results
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: iOS-Test-Results
+      #     path: TestResult-iOS.xml
 
   

--- a/.github/workflows/ios_navigation_tests.yml
+++ b/.github/workflows/ios_navigation_tests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run iOS Navigation Tests
         run: |
             #dotnet build TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj -c Debug --no-restore
-            dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "Category=PRNavTest&Category=iOS" --no-restore
+            dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "Category=PRNavTest" --no-restore
       #      dotnet tool install --global NUnit.ConsoleRunner.NetCore
       #      nunit3-console TransactionProcessor.Mobile.UiTests/bin/Release/net9.0/TransactionProcessor.Mobile.UiTests.dll --where "(cat == PRNavTest && cat == iOS)"
 

--- a/TestCategoryLister/Program.cs
+++ b/TestCategoryLister/Program.cs
@@ -13,7 +13,7 @@ class Program
             return;
         }
 
-        var path = "args[0]";
+        var path = args[0];
         var asm = Assembly.LoadFrom(path);
 
         foreach (var type in asm.GetTypes())

--- a/TestCategoryLister/Program.cs
+++ b/TestCategoryLister/Program.cs
@@ -13,7 +13,7 @@ class Program
             return;
         }
 
-        var path = args[0];
+        var path = "args[0]";
         var asm = Assembly.LoadFrom(path);
 
         foreach (var type in asm.GetTypes())

--- a/TestCategoryLister/Program.cs
+++ b/TestCategoryLister/Program.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        if (args.Length != 1)
+        {
+            Console.WriteLine("Usage: dotnet run <path-to-test-dll>");
+            return;
+        }
+
+        var path = args[0];
+        var asm = Assembly.LoadFrom(path);
+
+        foreach (var type in asm.GetTypes())
+        {
+            foreach (var method in type.GetMethods())
+            {
+                var testAttr = method.GetCustomAttribute<TestAttribute>();
+                if (testAttr != null)
+                {
+                    var categories = method.GetCustomAttributes<CategoryAttribute>()
+                        .Select(a => a.Name)
+                        .ToList();
+
+                    Console.WriteLine($"{type.FullName}.{method.Name} - Categories: {(categories.Count == 0 ? "None" : string.Join(", ", categories))}");
+                }
+            }
+        }
+    }
+}

--- a/TestCategoryLister/Program.cs
+++ b/TestCategoryLister/Program.cs
@@ -18,17 +18,20 @@ class Program
 
         foreach (var type in asm.GetTypes())
         {
-            foreach (var method in type.GetMethods())
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
             {
+                // Must be an [NUnit.Framework.Test] method
                 var testAttr = method.GetCustomAttribute<TestAttribute>();
-                if (testAttr != null)
-                {
-                    var categories = method.GetCustomAttributes<CategoryAttribute>()
-                        .Select(a => a.Name)
-                        .ToList();
+                if (testAttr is null)
+                    continue;
 
-                    Console.WriteLine($"{type.FullName}.{method.Name} - Categories: {(categories.Count == 0 ? "None" : string.Join(", ", categories))}");
-                }
+                // Collect [Category] from method and class
+                var methodCategories = method.GetCustomAttributes<CategoryAttribute>().Select(a => a.Name);
+                var classCategories = type.GetCustomAttributes<CategoryAttribute>().Select(a => a.Name);
+
+                var allCategories = methodCategories.Concat(classCategories).Distinct().ToList();
+
+                Console.WriteLine($"{type.FullName}.{method.Name} - Categories: {(allCategories.Count == 0 ? "None" : string.Join(", ", allCategories))}");
             }
         }
     }

--- a/TestCategoryLister/TestCategoryLister.csproj
+++ b/TestCategoryLister/TestCategoryLister.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="NUnit" Version="3.13.3" />
+	</ItemGroup>
+</Project>

--- a/TestCategoryLister/TestCategoryLister.csproj
+++ b/TestCategoryLister/TestCategoryLister.csproj
@@ -4,6 +4,6 @@
 		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit" Version="4.3.2" />
 	</ItemGroup>
 </Project>

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/ExtendedBaseViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/ExtendedBaseViewModel.cs
@@ -79,7 +79,7 @@ public class ExtendedBaseViewModel : BaseViewModel
     }
 
     private async Task ShowLoginPage() {
-
+        
         Boolean leave = await this.DialogService.ShowDialog("Title", "Logout Message", "yes", "no");
         if (leave) {
             Logger.LogInformation("LogoutCommand called");

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -86,7 +86,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.AddAdditionalAppiumOption("useNewWDA", false);
             caps.AddAdditionalAppiumOption("webDriverAgentUrl", "http://127.0.0.1:8100");
             caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            caps.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent");
+            //caps.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent");
 
             var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             caps.AddAdditionalAppiumOption("udid", udid);

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -85,6 +85,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.AddAdditionalAppiumOption("fullReset", false);
             caps.AddAdditionalAppiumOption("useNewWDA", false);
             caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            caps.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/Library/Developer/Xcode/DerivedData");
 
             var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             caps.AddAdditionalAppiumOption("udid", udid);

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -66,7 +66,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
 
         private static void SetupiOSDriver(AppiumLocalService appiumService) {
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
+            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-x64/");
             var apkPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
             
             var caps = new AppiumOptions();

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -66,8 +66,8 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
 
         private static void SetupiOSDriver(AppiumLocalService appiumService) {
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-arm64/");
-            var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
+            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
+            var apkPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
             
             var caps = new AppiumOptions();
             caps.PlatformName = "iOS";

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -145,17 +145,57 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             //driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true); // avoids extra processes
             //driverOptions.AddAdditionalAppiumOption("showXcodeLog", true); // shows build errors in logs
             //driverOptions.AddAdditionalAppiumOption("bundleId", "com.appium.WebDriverAgentRunner"); // match WDA bundle ID
-            var simulatorName = Environment.GetEnvironmentVariable("$SIMULATOR_NAME");
+            //var simulatorName = Environment.GetEnvironmentVariable("$SIMULATOR_NAME");
+            //var options = new AppiumOptions();
+            //options.PlatformName = "iOS";
+            //options.PlatformVersion = "18.0";
+
+            ////options.DeviceName = simulatorName;
+            //options.AutomationName = "XCUITest";
+            //options.App = appPath;
+            //options.AddAdditionalAppiumOption("bundleId", "com.transactionprocessor.mobile");
+            //options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            //options.AddAdditionalAppiumOption("useNewWDA", false);
+            //options.AddAdditionalAppiumOption("skipDeviceInitialization", true);
+            //options.AddAdditionalAppiumOption("wdaStartupRetries", 1);
+            //options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+            //options.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true);
+            //options.AddAdditionalAppiumOption("connectHardwareKeyboard", false);
+            //options.AddAdditionalAppiumOption("waitForQuiescence", true);
+            //options.AddAdditionalAppiumOption("wdaLocalPort", 8100);
+            //options.AddAdditionalAppiumOption("startIWDP", false); // Unless you need Safari/WebView debugging
+            //options.AddAdditionalAppiumOption("preventWDAAttachments", true);
+            //var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID");
+
+            //if (string.IsNullOrWhiteSpace(simulatorId))
+            //    throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
+
+            //options.AddAdditionalAppiumOption("udid", simulatorId);
             var options = new AppiumOptions();
             options.PlatformName = "iOS";
             options.PlatformVersion = "18.0";
-            
-            //options.DeviceName = simulatorName;
             options.AutomationName = "XCUITest";
-            options.App = appPath;
-            options.AddAdditionalAppiumOption("bundleId", "com.transactionprocessor.mobile");
+            options.DeviceName = "iPhone 16"; // Ensure you keep this for parity
+            options.App = appPath;            // Keep this OR bundleId, not both
+            // options.AddAdditionalAppiumOption("bundleId", "com.transactionprocessor.mobile"); // REMOVE unless app is preinstalled
+
+            // Environment var check
+            var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID")?.Trim();
+            if (string.IsNullOrWhiteSpace(simulatorId))
+                throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
+
+            options.AddAdditionalAppiumOption("udid", simulatorId);
+
+            // Matching other working config
             options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
             options.AddAdditionalAppiumOption("useNewWDA", false);
+            options.AddAdditionalAppiumOption("webDriverAgentUrl", "http://127.0.0.1:8100");
+            options.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent");
+
+            options.AddAdditionalAppiumOption("noReset", true);
+            options.AddAdditionalAppiumOption("fullReset", false);
+
+            // Optionally keep the rest if needed
             options.AddAdditionalAppiumOption("skipDeviceInitialization", true);
             options.AddAdditionalAppiumOption("wdaStartupRetries", 1);
             options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
@@ -163,18 +203,11 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             options.AddAdditionalAppiumOption("connectHardwareKeyboard", false);
             options.AddAdditionalAppiumOption("waitForQuiescence", true);
             options.AddAdditionalAppiumOption("wdaLocalPort", 8100);
-            options.AddAdditionalAppiumOption("startIWDP", false); // Unless you need Safari/WebView debugging
+            options.AddAdditionalAppiumOption("startIWDP", false);
             options.AddAdditionalAppiumOption("preventWDAAttachments", true);
-            var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID");
 
-            if (string.IsNullOrWhiteSpace(simulatorId))
-                throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
 
-            options.AddAdditionalAppiumOption("udid", simulatorId);
-
-            //var capabilities = options.ToCapabilities() as ICapabilities;
-
-            Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(options));
+            Console.WriteLine(simulatorId);
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(2));
         }

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -67,29 +67,29 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
         private static void SetupiOSDriver(AppiumLocalService appiumService) {
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
-            var apkPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
-            
-            var caps = new AppiumOptions();
-            caps.PlatformName = "iOS";
-            caps.PlatformVersion = "18.0";
-            caps.DeviceName = "iPhone 16";
-            caps.AutomationName = "XCUITest";
-            caps.App = apkPath;
+            var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
+
+            //var caps = new AppiumOptions();
+            //caps.PlatformName = "iOS";
+            //caps.PlatformVersion = "18.0";
+            //caps.DeviceName = "iPhone 16";
+            //caps.AutomationName = "XCUITest";
+            //caps.App = apkPath;
             // original code
             //caps.AddAdditionalAppiumOption("fullReset", true);
             //caps.AddAdditionalAppiumOption("noReset", false);
             //caps.AddAdditionalAppiumOption("useNewWDA", true);
             //caps.AddAdditionalAppiumOption("launchTimeout", 300000); // 5 minutes
             // original code
-            caps.AddAdditionalAppiumOption("noReset", true);
-            caps.AddAdditionalAppiumOption("fullReset", false);
-            caps.AddAdditionalAppiumOption("useNewWDA", false);
-            caps.AddAdditionalAppiumOption("webDriverAgentUrl", "http://127.0.0.1:8100");
-            caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            //caps.AddAdditionalAppiumOption("noReset", true);
+            //caps.AddAdditionalAppiumOption("fullReset", false);
+            //caps.AddAdditionalAppiumOption("useNewWDA", false);
+            //caps.AddAdditionalAppiumOption("webDriverAgentUrl", "http://127.0.0.1:8100");
+            //caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
             //caps.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent");
 
-            var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
-            caps.AddAdditionalAppiumOption("udid", udid);
+            //var simulatorName = Environment.GetEnvironmentVariable("$SIMULATOR_NAME");
+            //caps.AddAdditionalAppiumOption("udid", udid);
             //var driverOptions = new AppiumOptions();
             //driverOptions.AutomationName = "XCUITest";
             ////driverOptions.PlatformName = "iOS";
@@ -145,9 +145,27 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             //driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true); // avoids extra processes
             //driverOptions.AddAdditionalAppiumOption("showXcodeLog", true); // shows build errors in logs
             //driverOptions.AddAdditionalAppiumOption("bundleId", "com.appium.WebDriverAgentRunner"); // match WDA bundle ID
-
-
-            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, caps, TimeSpan.FromMinutes(10));
+            var simulatorName = Environment.GetEnvironmentVariable("$SIMULATOR_NAME");
+            var options = new AppiumOptions();
+            options.PlatformName = "iOS";
+            options.PlatformVersion = "18.0";
+            options.DeviceName = simulatorName;
+            options.AutomationName = "XCUITest";
+            options.App = appPath;
+            options.AddAdditionalAppiumOption("bundleId", "com.transactionprocessor.mobile");
+            options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            options.AddAdditionalAppiumOption("useNewWDA", false);
+            options.AddAdditionalAppiumOption("skipDeviceInitialization", true);
+            options.AddAdditionalAppiumOption("wdaStartupRetries", 1);
+            options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+            options.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true);
+            options.AddAdditionalAppiumOption("connectHardwareKeyboard", false);
+            options.AddAdditionalAppiumOption("waitForQuiescence", true);
+            options.AddAdditionalAppiumOption("wdaLocalPort", 8100);
+            options.AddAdditionalAppiumOption("startIWDP", false); // Unless you need Safari/WebView debugging
+            options.AddAdditionalAppiumOption("preventWDAAttachments", true);
+            
+            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(10));
         }
 
         private static void SetupAndroidDriver(AppiumLocalService appiumService) {

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -66,7 +66,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
 
         private static void SetupiOSDriver(AppiumLocalService appiumService) {
             String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-x64/");
+            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
             var apkPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
             
             var caps = new AppiumOptions();

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -149,6 +149,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             var options = new AppiumOptions();
             options.PlatformName = "iOS";
             options.PlatformVersion = "18.0";
+            
             //options.DeviceName = simulatorName;
             options.AutomationName = "XCUITest";
             options.App = appPath;
@@ -165,6 +166,10 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             options.AddAdditionalAppiumOption("startIWDP", false); // Unless you need Safari/WebView debugging
             options.AddAdditionalAppiumOption("preventWDAAttachments", true);
             var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID");
+
+            if (string.IsNullOrWhiteSpace(simulatorId))
+                throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
+
             options.AddAdditionalAppiumOption("udid", simulatorId);
             
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(2));

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -85,7 +85,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.AddAdditionalAppiumOption("fullReset", false);
             caps.AddAdditionalAppiumOption("useNewWDA", false);
             caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            caps.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/Library/Developer/Xcode/DerivedData");
+            caps.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent");
 
             var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             caps.AddAdditionalAppiumOption("udid", udid);

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -84,6 +84,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.AddAdditionalAppiumOption("noReset", true);
             caps.AddAdditionalAppiumOption("fullReset", false);
             caps.AddAdditionalAppiumOption("useNewWDA", false);
+            caps.AddAdditionalAppiumOption("webDriverAgentUrl", "http://127.0.0.1:8100");
             caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
             caps.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent");
 

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -78,7 +78,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.AddAdditionalAppiumOption("fullReset", true);
             caps.AddAdditionalAppiumOption("noReset", false);
             caps.AddAdditionalAppiumOption("useNewWDA", true);
-            
+            caps.AddAdditionalAppiumOption("launchTimeout", 300000); // 5 minutes
             var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             caps.AddAdditionalAppiumOption("udid", udid);
             //var driverOptions = new AppiumOptions();

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -149,7 +149,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             var options = new AppiumOptions();
             options.PlatformName = "iOS";
             options.PlatformVersion = "18.0";
-            options.DeviceName = simulatorName;
+            //options.DeviceName = simulatorName;
             options.AutomationName = "XCUITest";
             options.App = appPath;
             options.AddAdditionalAppiumOption("bundleId", "com.transactionprocessor.mobile");
@@ -164,8 +164,10 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             options.AddAdditionalAppiumOption("wdaLocalPort", 8100);
             options.AddAdditionalAppiumOption("startIWDP", false); // Unless you need Safari/WebView debugging
             options.AddAdditionalAppiumOption("preventWDAAttachments", true);
+            var simulatorId = Environment.GetEnvironmentVariable("$SIMULATOR_ID");
+            options.AddAdditionalAppiumOption("udid", simulatorId);
             
-            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(10));
+            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(2));
         }
 
         private static void SetupAndroidDriver(AppiumLocalService appiumService) {

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -208,7 +208,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             options.AddAdditionalAppiumOption("fullReset", false);
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(
-                new Uri("http://127.0.0.1:4723/wd/hub"), options, TimeSpan.FromMinutes(2));
+                new Uri("http://127.0.0.1:4723/"), options, TimeSpan.FromMinutes(2));
         }
 
         private static void SetupAndroidDriver(AppiumLocalService appiumService) {

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -75,10 +75,17 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.DeviceName = "iPhone 16";
             caps.AutomationName = "XCUITest";
             caps.App = apkPath;
-            caps.AddAdditionalAppiumOption("fullReset", true);
-            caps.AddAdditionalAppiumOption("noReset", false);
-            caps.AddAdditionalAppiumOption("useNewWDA", true);
-            caps.AddAdditionalAppiumOption("launchTimeout", 300000); // 5 minutes
+            // original code
+            //caps.AddAdditionalAppiumOption("fullReset", true);
+            //caps.AddAdditionalAppiumOption("noReset", false);
+            //caps.AddAdditionalAppiumOption("useNewWDA", true);
+            //caps.AddAdditionalAppiumOption("launchTimeout", 300000); // 5 minutes
+            // original code
+            caps.AddAdditionalAppiumOption("noReset", true);
+            caps.AddAdditionalAppiumOption("fullReset", false);
+            caps.AddAdditionalAppiumOption("useNewWDA", false);
+            caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+
             var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             caps.AddAdditionalAppiumOption("udid", udid);
             //var driverOptions = new AppiumOptions();

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -78,6 +78,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.AddAdditionalAppiumOption("fullReset", false);
             caps.AddAdditionalAppiumOption("noReset", true);
             //caps.AddAdditionalAppiumOption("useNewWDA", true);
+            caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
             var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             caps.AddAdditionalAppiumOption("udid", udid);
             //var driverOptions = new AppiumOptions();

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -172,9 +172,9 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
 
             options.AddAdditionalAppiumOption("udid", simulatorId);
 
-            var capabilities = options.ToCapabilities() as ICapabilities;
+            //var capabilities = options.ToCapabilities() as ICapabilities;
 
-            Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(capabilities));
+            Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(options));
 
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(2));
         }

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -177,7 +177,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             options.AutomationName = "XCUITest";
             options.DeviceName = "iPhone 16"; // Ensure you keep this for parity
             options.App = appPath;            // Keep this OR bundleId, not both
-            // options.AddAdditionalAppiumOption("bundleId", "com.transactionprocessor.mobile"); // REMOVE unless app is preinstalled
+            options.AddAdditionalAppiumOption("bundleId", "com.transactionprocessor.mobile"); // REMOVE unless app is preinstalled
 
             // Environment var check
             var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID")?.Trim();

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -77,7 +77,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.App = apkPath;
             caps.AddAdditionalAppiumOption("fullReset", true);
             caps.AddAdditionalAppiumOption("noReset", false);
-            caps.AddAdditionalAppiumOption("useNewWDA", true);
+            //caps.AddAdditionalAppiumOption("useNewWDA", true);
             var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             caps.AddAdditionalAppiumOption("udid", udid);
             //var driverOptions = new AppiumOptions();

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -75,10 +75,10 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.DeviceName = "iPhone 16";
             caps.AutomationName = "XCUITest";
             caps.App = apkPath;
-            caps.AddAdditionalAppiumOption("fullReset", false);
-            caps.AddAdditionalAppiumOption("noReset", true);
-            //caps.AddAdditionalAppiumOption("useNewWDA", true);
-            caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            caps.AddAdditionalAppiumOption("fullReset", true);
+            caps.AddAdditionalAppiumOption("noReset", false);
+            caps.AddAdditionalAppiumOption("useNewWDA", true);
+            
             var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             caps.AddAdditionalAppiumOption("udid", udid);
             //var driverOptions = new AppiumOptions();

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -78,7 +78,8 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.AddAdditionalAppiumOption("fullReset", true);
             caps.AddAdditionalAppiumOption("noReset", false);
             caps.AddAdditionalAppiumOption("useNewWDA", true);
-
+            var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
+            caps.AddAdditionalAppiumOption("udid", udid);
             //var driverOptions = new AppiumOptions();
             //driverOptions.AutomationName = "XCUITest";
             ////driverOptions.PlatformName = "iOS";

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -171,7 +171,11 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
                 throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
 
             options.AddAdditionalAppiumOption("udid", simulatorId);
-            
+
+            var capabilities = options.ToCapabilities() as ICapabilities;
+
+            Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(capabilities));
+
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(2));
         }
 

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -75,8 +75,8 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             caps.DeviceName = "iPhone 16";
             caps.AutomationName = "XCUITest";
             caps.App = apkPath;
-            caps.AddAdditionalAppiumOption("fullReset", true);
-            caps.AddAdditionalAppiumOption("noReset", false);
+            caps.AddAdditionalAppiumOption("fullReset", false);
+            caps.AddAdditionalAppiumOption("noReset", true);
             //caps.AddAdditionalAppiumOption("useNewWDA", true);
             var udid = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             caps.AddAdditionalAppiumOption("udid", udid);

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -22,23 +22,27 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
         public static MobileTestPlatform MobileTestPlatform;
         public static AppiumDriver Driver;
 
-        public void StartApp() {
+        public void StartApp()
+        {
             AppiumLocalService appiumService = new AppiumServiceBuilder().UsingPort(4723).Build();
-            
-            if (appiumService.IsRunning == false){
+
+            if (appiumService.IsRunning == false)
+            {
                 appiumService.OutputDataReceived += (sender,
                                                      args) => {
-                                                        //Console.WriteLine(args.Data);
-                                                        Debug.WriteLine(args.Data);
-                                                    };
+                                                         Console.WriteLine(args.Data);
+                                                         Debug.WriteLine(args.Data);
+                                                     };
                 appiumService.Start();
             }
 
-            if (AppiumDriverWrapper.MobileTestPlatform == MobileTestPlatform.Android){
+            if (AppiumDriverWrapper.MobileTestPlatform == MobileTestPlatform.Android)
+            {
                 AppiumDriverWrapper.SetupAndroidDriver(appiumService);
             }
-            else if (AppiumDriverWrapper.MobileTestPlatform == MobileTestPlatform.iOS){
-                AppiumDriverWrapper.SetupiOSDriverX();
+            else if (AppiumDriverWrapper.MobileTestPlatform == MobileTestPlatform.iOS)
+            {
+                AppiumDriverWrapper.SetupiOSDriverNew(appiumService);
             }
             else if (AppiumDriverWrapper.MobileTestPlatform == MobileTestPlatform.Windows)
             {
@@ -46,7 +50,8 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             }
         }
 
-        private static void SetupWindowsDriver(AppiumLocalService appiumService){
+        private static void SetupWindowsDriver(AppiumLocalService appiumService)
+        {
             var driverOptions = new AppiumOptions();
             driverOptions.AutomationName = "windows";
             driverOptions.PlatformName = "windows";
@@ -60,165 +65,89 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             AppiumDriverWrapper.Driver = new WindowsDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
         }
 
-        public static void SetupiOSDriverX() {
-            String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
-            var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
+        public static void SetupiOSDriverX()
+        {
+            //String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            //String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
+            //var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
+            var appPath = "/Users/user272907/Documents/Projects/TransactionMobile/TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/TransactionProcessor.Mobile.app";
+            var exists = Directory.Exists(appPath);
             var options = new AppiumOptions();
             options.PlatformName = "iOS";
-            options.PlatformVersion = "18.0";
+            options.PlatformVersion = "18.3";
             options.AutomationName = "XCUITest";
             options.DeviceName = "iPhone 16";
             options.App = appPath; // Only if you want Appium to install the app
 
-            var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID")?.Trim();
-            if (string.IsNullOrWhiteSpace(simulatorId))
-                throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
-            options.AddAdditionalAppiumOption("udid", simulatorId);
-
-            options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            options.AddAdditionalAppiumOption("noReset", true);
-            options.AddAdditionalAppiumOption("fullReset", false);
-
-            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(
-                new Uri("http://127.0.0.1:4723/wd/hub"), options, TimeSpan.FromMinutes(2));
-        }
-
-        private static void SetupiOSDriver(AppiumLocalService appiumService) {
-            String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
-            var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
-
-            //var caps = new AppiumOptions();
-            //caps.PlatformName = "iOS";
-            //caps.PlatformVersion = "18.0";
-            //caps.DeviceName = "iPhone 16";
-            //caps.AutomationName = "XCUITest";
-            //caps.App = apkPath;
-            // original code
-            //caps.AddAdditionalAppiumOption("fullReset", true);
-            //caps.AddAdditionalAppiumOption("noReset", false);
-            //caps.AddAdditionalAppiumOption("useNewWDA", true);
-            //caps.AddAdditionalAppiumOption("launchTimeout", 300000); // 5 minutes
-            // original code
-            //caps.AddAdditionalAppiumOption("noReset", true);
-            //caps.AddAdditionalAppiumOption("fullReset", false);
-            //caps.AddAdditionalAppiumOption("useNewWDA", false);
-            //caps.AddAdditionalAppiumOption("webDriverAgentUrl", "http://127.0.0.1:8100");
-            //caps.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            //caps.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/Library/Developer/Xcode/DerivedData/WebDriverAgent");
-
-            //var simulatorName = Environment.GetEnvironmentVariable("$SIMULATOR_NAME");
-            //caps.AddAdditionalAppiumOption("udid", udid);
-            //var driverOptions = new AppiumOptions();
-            //driverOptions.AutomationName = "XCUITest";
-            ////driverOptions.PlatformName = "iOS";
-            ////driverOptions.PlatformVersion = "17.4";
-            ////driverOptions.DeviceName = "iPhone 11";
-            //driverOptions.AutomationName = "XCUITest";
-            //driverOptions.PlatformName = "iOS";
-            //driverOptions.PlatformVersion = "17.2";
-            //driverOptions.AddAdditionalAppiumOption("udid", Environment.GetEnvironmentVariable("UDID")); // Corrected capability.
-
-            //String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            //String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionMobile.Maui/bin/Release/net8.0-ios/iossimulator-arm64/");
-            //var apkPath = Path.Combine(binariesFolder, "TransactionMobile.Maui.app");
-            //driverOptions.App = apkPath;
-            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NewCommandTimeout, 6000);
-            //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
-            //driverOptions.AddAdditionalAppiumOption("shouldWaitForQuiescence", false);
-            //driverOptions.AddAdditionalAppiumOption("showXcodeLog", true);
-            ////driverOptions.AddAdditionalAppiumOption("useNewWDA", true);
-            ////driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
-            ////driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 60000);
-            ////driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 120000);
-            ////driverOptions.AddAdditionalAppiumOption("wdaConnectionTimeout", 120000);
-            ////driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
-            ////driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
-            ////driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 4);
-            //driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            //driverOptions.AddAdditionalAppiumOption("skipServerInstallation", true);
-            //driverOptions.AddAdditionalAppiumOption("skipProvisioningDeviceDetection", true);
-            //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", Environment.GetEnvironmentVariable("WDA_PATH"));
-            //driverOptions.AddAdditionalAppiumOption("updatedWDABundleId", "WebDriverAgent/build");
-            // Tell Appium to use the prebuilt WDA
-            //driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            //driverOptions.AddAdditionalAppiumOption("useNewWDA", false);
-            //driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true);
-
-            //driverOptions.AddAdditionalAppiumOption("derivedDataPath", "/Users/runner/work/WebDriverAgent/build/Build/Products/Debug-iphonesimulator");
-            //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100);
-
-
-            //// Avoid unnecessary WDA rebuild attempts and add resilience
-            //driverOptions.AddAdditionalAppiumOption("wdaLaunchTimeout", 60000);
-            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetries", 3);
-            //driverOptions.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
-
-            //// (Optional but often helpful)
-            //driverOptions.AddAdditionalAppiumOption("waitForQuiescence", false);
-            //driverOptions.AddAdditionalAppiumOption("startIWDP", true); // if you want to inspect webviews
-            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, false);
-            //driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.NoReset, true);
-            //driverOptions.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            //driverOptions.AddAdditionalAppiumOption("wdaLocalPort", 8100); // optional, but helpful
-            //driverOptions.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true); // avoids extra processes
-            //driverOptions.AddAdditionalAppiumOption("showXcodeLog", true); // shows build errors in logs
-            //driverOptions.AddAdditionalAppiumOption("bundleId", "com.appium.WebDriverAgentRunner"); // match WDA bundle ID
-            //var simulatorName = Environment.GetEnvironmentVariable("$SIMULATOR_NAME");
-            //var options = new AppiumOptions();
-            //options.PlatformName = "iOS";
-            //options.PlatformVersion = "18.0";
-
-            ////options.DeviceName = simulatorName;
-            //options.AutomationName = "XCUITest";
-            //options.App = appPath;
-            //options.AddAdditionalAppiumOption("bundleId", "com.transactionprocessor.mobile");
-            //options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            //options.AddAdditionalAppiumOption("useNewWDA", false);
-            //options.AddAdditionalAppiumOption("skipDeviceInitialization", true);
-            //options.AddAdditionalAppiumOption("wdaStartupRetries", 1);
-            //options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
-            //options.AddAdditionalAppiumOption("shouldUseSingletonTestManager", true);
-            //options.AddAdditionalAppiumOption("connectHardwareKeyboard", false);
-            //options.AddAdditionalAppiumOption("waitForQuiescence", true);
-            //options.AddAdditionalAppiumOption("wdaLocalPort", 8100);
-            //options.AddAdditionalAppiumOption("startIWDP", false); // Unless you need Safari/WebView debugging
-            //options.AddAdditionalAppiumOption("preventWDAAttachments", true);
-            //var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID");
-
+            //var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID")?.Trim();
             //if (string.IsNullOrWhiteSpace(simulatorId))
             //    throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
-
             //options.AddAdditionalAppiumOption("udid", simulatorId);
+
+            //options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            //options.AddAdditionalAppiumOption("noReset", true);
+            //options.AddAdditionalAppiumOption("fullReset", false);
+            options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+            options.AddAdditionalAppiumOption("derivedDataPath", "~/Library/Developer/Xcode/DerivedData/WebDriverAgent-hjlcwhatzxfnnggzdecgbewgjzil");
+            options.AddAdditionalAppiumOption("wdaStartupRetries", 2);
+            options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+            options.AddAdditionalAppiumOption("showXcodeLog", true);
+            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(
+                new Uri("http://127.0.0.1:4723"), options, TimeSpan.FromMinutes(2));
+        }
+
+        private static void SetupiOSDriverNew(AppiumLocalService appiumService)
+        {
+            String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
+            var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
+
             var options = new AppiumOptions();
             options.PlatformName = "iOS";
-            options.PlatformVersion = "18.0";
+            options.DeviceName = "";
+            options.AddAdditionalAppiumOption("udid", "0A7AD110-C0C0-45BC-BCBC-8091AC55FF18");
+            options.App = appPath;
+            //options.AddAdditionalAppiumOption("bundleId", "com.apple.Preferences");
+            options.AutomationName = "XCUITest";
+            options.AddAdditionalAppiumOption("useNewWDA", true);
+            options.AddAdditionalAppiumOption("autoAcceptAlerts", true);
+            options.AddAdditionalAppiumOption("wdaStartupRetries", 3);
+            options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 5000);
+            options.AddAdditionalAppiumOption("showXcodeLog", true);
+            options.AddAdditionalAppiumOption("waitForIdleTimeout", 100);
+            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options);
+        }
+
+        private static void SetupiOSDriver(AppiumLocalService appiumService)
+        {
+            String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
+            var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
+
+            var options = new AppiumOptions();
+            options.PlatformName = "iOS";
+            options.PlatformVersion = "18.3";
             options.AutomationName = "XCUITest";
             options.DeviceName = "iPhone 16";
             options.App = appPath; // Only if you want Appium to install the app
-
-            var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID")?.Trim();
-            if (string.IsNullOrWhiteSpace(simulatorId))
-                throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
-            options.AddAdditionalAppiumOption("udid", simulatorId);
-
+                                   //options.AddAdditionalAppiumOption("useNewWDA", true); // Rebuild WDA
             options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            options.AddAdditionalAppiumOption("noReset", true);
-            options.AddAdditionalAppiumOption("fullReset", false);
+            options.AddAdditionalAppiumOption("derivedDataPath", "~/Library/Developer/Xcode/DerivedData/WebDriverAgent-hjlcwhatzxfnnggzdecgbewgjziloption");
+            options.AddAdditionalAppiumOption("wdaStartupRetries", 2);
+            options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
 
-            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(
-                new Uri("http://127.0.0.1:4723/"), options, TimeSpan.FromMinutes(2));
+            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(2));
         }
 
-        private static void SetupAndroidDriver(AppiumLocalService appiumService) {
+        private static void SetupAndroidDriver(AppiumLocalService appiumService)
+        {
             var driverOptions = new AppiumOptions();
             driverOptions.AddAdditionalAppiumOption("adbExecTimeout", TimeSpan.FromMinutes(5).TotalMilliseconds);
             driverOptions.AutomationName = "UIAutomator2";
             driverOptions.PlatformName = "Android";
             driverOptions.PlatformVersion = "15.0";
             driverOptions.DeviceName = "emulator-5554";
-            
+
             driverOptions.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, true);
             driverOptions.AddAdditionalAppiumOption("appPackage", "com.transactionprocessor.mobile");
             driverOptions.AddAdditionalAppiumOption("enforceAppInstall", true);
@@ -232,13 +161,16 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             var fileinfo = new FileInfo(apkPath);
 
             driverOptions.App = apkPath;
-            
+
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.Android.AndroidDriver(appiumService, driverOptions, TimeSpan.FromMinutes(5));
         }
 
-        public List<LogEntry> GetLogs() {
-            if (AppiumDriverWrapper.MobileTestPlatform == MobileTestPlatform.Android) {
-                if (AppiumDriverWrapper.Driver == null) {
+        public List<LogEntry> GetLogs()
+        {
+            if (AppiumDriverWrapper.MobileTestPlatform == MobileTestPlatform.Android)
+            {
+                if (AppiumDriverWrapper.Driver == null)
+                {
                     return new List<LogEntry>();
                 }
                 ReadOnlyCollection<LogEntry>? logs = AppiumDriverWrapper.Driver.Manage().Logs.GetLog("logcat");
@@ -250,11 +182,13 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
 
         public void StopApp()
         {
-            try {
+            try
+            {
                 AppiumDriverWrapper.Driver?.Close();
                 AppiumDriverWrapper.Driver?.Quit();
             }
-            catch(Exception e) {
+            catch (Exception e)
+            {
                 Console.WriteLine(e.Message);
             }
         }

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -65,36 +65,36 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             AppiumDriverWrapper.Driver = new WindowsDriver(appiumService, driverOptions, TimeSpan.FromMinutes(10));
         }
 
-        public static void SetupiOSDriverX()
-        {
-            //String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            //String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
-            //var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
-            var appPath = "/Users/user272907/Documents/Projects/TransactionMobile/TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/TransactionProcessor.Mobile.app";
-            var exists = Directory.Exists(appPath);
-            var options = new AppiumOptions();
-            options.PlatformName = "iOS";
-            options.PlatformVersion = "18.3";
-            options.AutomationName = "XCUITest";
-            options.DeviceName = "iPhone 16";
-            options.App = appPath; // Only if you want Appium to install the app
+        //public static void SetupiOSDriverX()
+        //{
+        //    //String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        //    //String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
+        //    //var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
+        //    var appPath = "/Users/user272907/Documents/Projects/TransactionMobile/TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/TransactionProcessor.Mobile.app";
+        //    var exists = Directory.Exists(appPath);
+        //    var options = new AppiumOptions();
+        //    options.PlatformName = "iOS";
+        //    options.PlatformVersion = "18.3";
+        //    options.AutomationName = "XCUITest";
+        //    options.DeviceName = "iPhone 16";
+        //    options.App = appPath; // Only if you want Appium to install the app
 
-            //var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID")?.Trim();
-            //if (string.IsNullOrWhiteSpace(simulatorId))
-            //    throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
-            //options.AddAdditionalAppiumOption("udid", simulatorId);
+        //    //var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID")?.Trim();
+        //    //if (string.IsNullOrWhiteSpace(simulatorId))
+        //    //    throw new InvalidOperationException("SIMULATOR_ID environment variable is not set.");
+        //    //options.AddAdditionalAppiumOption("udid", simulatorId);
 
-            //options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            //options.AddAdditionalAppiumOption("noReset", true);
-            //options.AddAdditionalAppiumOption("fullReset", false);
-            options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            options.AddAdditionalAppiumOption("derivedDataPath", "~/Library/Developer/Xcode/DerivedData/WebDriverAgent-hjlcwhatzxfnnggzdecgbewgjzil");
-            options.AddAdditionalAppiumOption("wdaStartupRetries", 2);
-            options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
-            options.AddAdditionalAppiumOption("showXcodeLog", true);
-            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(
-                new Uri("http://127.0.0.1:4723"), options, TimeSpan.FromMinutes(2));
-        }
+        //    //options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+        //    //options.AddAdditionalAppiumOption("noReset", true);
+        //    //options.AddAdditionalAppiumOption("fullReset", false);
+        //    options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+        //    options.AddAdditionalAppiumOption("derivedDataPath", "~/Library/Developer/Xcode/DerivedData/WebDriverAgent-hjlcwhatzxfnnggzdecgbewgjzil");
+        //    options.AddAdditionalAppiumOption("wdaStartupRetries", 2);
+        //    options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+        //    options.AddAdditionalAppiumOption("showXcodeLog", true);
+        //    AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(
+        //        new Uri("http://127.0.0.1:4723"), options, TimeSpan.FromMinutes(2));
+        //}
 
         private static void SetupiOSDriverNew(AppiumLocalService appiumService)
         {
@@ -105,7 +105,9 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             var options = new AppiumOptions();
             options.PlatformName = "iOS";
             options.DeviceName = "";
-            options.AddAdditionalAppiumOption("udid", "0A7AD110-C0C0-45BC-BCBC-8091AC55FF18");
+            //options.AddAdditionalAppiumOption("udid", "0A7AD110-C0C0-45BC-BCBC-8091AC55FF18");
+            var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID")?.Trim();
+            options.AddAdditionalAppiumOption("udid", simulatorId);
             options.App = appPath;
             //options.AddAdditionalAppiumOption("bundleId", "com.apple.Preferences");
             options.AutomationName = "XCUITest";
@@ -118,26 +120,26 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options);
         }
 
-        private static void SetupiOSDriver(AppiumLocalService appiumService)
-        {
-            String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
-            var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
+        //private static void SetupiOSDriver(AppiumLocalService appiumService)
+        //{
+        //    String assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        //    String binariesFolder = Path.Combine(assemblyFolder, "..", "..", "..", "..", @"TransactionProcessor.Mobile/bin/Release/net9.0-ios/iossimulator-arm64/");
+        //    var appPath = Path.Combine(binariesFolder, "TransactionProcessor.Mobile.app");
 
-            var options = new AppiumOptions();
-            options.PlatformName = "iOS";
-            options.PlatformVersion = "18.3";
-            options.AutomationName = "XCUITest";
-            options.DeviceName = "iPhone 16";
-            options.App = appPath; // Only if you want Appium to install the app
-                                   //options.AddAdditionalAppiumOption("useNewWDA", true); // Rebuild WDA
-            options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
-            options.AddAdditionalAppiumOption("derivedDataPath", "~/Library/Developer/Xcode/DerivedData/WebDriverAgent-hjlcwhatzxfnnggzdecgbewgjziloption");
-            options.AddAdditionalAppiumOption("wdaStartupRetries", 2);
-            options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
+        //    var options = new AppiumOptions();
+        //    options.PlatformName = "iOS";
+        //    options.PlatformVersion = "18.3";
+        //    options.AutomationName = "XCUITest";
+        //    options.DeviceName = "iPhone 16";
+        //    options.App = appPath; // Only if you want Appium to install the app
+        //                           //options.AddAdditionalAppiumOption("useNewWDA", true); // Rebuild WDA
+        //    options.AddAdditionalAppiumOption("usePrebuiltWDA", true);
+        //    options.AddAdditionalAppiumOption("derivedDataPath", "~/Library/Developer/Xcode/DerivedData/WebDriverAgent-hjlcwhatzxfnnggzdecgbewgjziloption");
+        //    options.AddAdditionalAppiumOption("wdaStartupRetries", 2);
+        //    options.AddAdditionalAppiumOption("wdaStartupRetryInterval", 10000);
 
-            AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(2));
-        }
+        //    AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(2));
+        //}
 
         private static void SetupAndroidDriver(AppiumLocalService appiumService)
         {

--- a/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
+++ b/TransactionProcessor.Mobile.UITests/Drivers/AppiumDriver.cs
@@ -164,7 +164,7 @@ namespace TransactionProcessor.Mobile.UITests.Drivers
             options.AddAdditionalAppiumOption("wdaLocalPort", 8100);
             options.AddAdditionalAppiumOption("startIWDP", false); // Unless you need Safari/WebView debugging
             options.AddAdditionalAppiumOption("preventWDAAttachments", true);
-            var simulatorId = Environment.GetEnvironmentVariable("$SIMULATOR_ID");
+            var simulatorId = Environment.GetEnvironmentVariable("SIMULATOR_ID");
             options.AddAdditionalAppiumOption("udid", simulatorId);
             
             AppiumDriverWrapper.Driver = new OpenQA.Selenium.Appium.iOS.IOSDriver(appiumService, options, TimeSpan.FromMinutes(2));

--- a/TransactionProcessor.Mobile.UITests/Features/PageNavigation.feature
+++ b/TransactionProcessor.Mobile.UITests/Features/PageNavigation.feature
@@ -8,7 +8,7 @@ Scenario: Back Button from Login Screen
 	Then The application closes
 
 # Home Page Back Button Tests
-@PRNavTest
+#@PRNavTest
 Scenario: Back Button from Home Page Screen
 	Given I am on the Login Screen
 	And the application is in training mode

--- a/TransactionProcessor.Mobile.UITests/Pages/LoginPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/LoginPage.cs
@@ -8,7 +8,7 @@ namespace TransactionProcessor.Mobile.UITests.Pages;
 public class LoginPage : BasePage2
 {
     protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch {
-        MobileTestPlatform.iOS => "Login Label",
+        MobileTestPlatform.iOS => "LoginLabel",
         _ => "LoginLabel"
     };
 

--- a/TransactionProcessor.Mobile.UITests/Pages/LoginPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/LoginPage.cs
@@ -7,7 +7,10 @@ namespace TransactionProcessor.Mobile.UITests.Pages;
 
 public class LoginPage : BasePage2
 {
-    protected override String Trait => "LoginLabel";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch {
+        MobileTestPlatform.iOS => "Login Label",
+        _ => "LoginLabel"
+    };
 
     private readonly String UserNameEntry;
     private readonly String PasswordEntry;

--- a/TransactionProcessor.Mobile.UITests/Pages/ProfileAccountInfoPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/ProfileAccountInfoPage.cs
@@ -1,4 +1,5 @@
 ﻿using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -35,7 +36,11 @@ public class ProfileAccountInfoPage : BasePage2
 
     #region Properties
 
-    protected override String Trait => "MyDetails";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "My Details",
+        _ => "MyDetails"
+    };
 
     #endregion
 

--- a/TransactionProcessor.Mobile.UITests/Pages/ProfileAddressesPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/ProfileAddressesPage.cs
@@ -1,4 +1,5 @@
 ﻿using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -42,7 +43,11 @@ public class ProfileAddressesPage : BasePage2
 
     #region Properties
 
-    protected override String Trait => "MyAddresses";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "My Addresses",
+        _ => "MyAddresses"
+    };
 
     #endregion
 

--- a/TransactionProcessor.Mobile.UITests/Pages/ProfileContactsPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/ProfileContactsPage.cs
@@ -1,4 +1,5 @@
 ﻿using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -30,7 +31,12 @@ public class ProfileContactsPage : BasePage2
 
     #region Properties
 
-    protected override String Trait => "MyContacts";
+    //protected override String Trait => "MyContacts";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "My Contacts",
+        _ => "MyContacts"
+    };
 
     #endregion
 

--- a/TransactionProcessor.Mobile.UITests/Pages/SalesAnalysisPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/SalesAnalysisPage.cs
@@ -5,7 +5,11 @@ namespace TransactionProcessor.Mobile.UITests.Pages;
 
 public class SalesAnalysisPage : BasePage2
 {
-    protected override String Trait => "SalesAnalysis";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Sales Analysis",
+        _ => "SalesAnalysis"
+    };
 
     public SalesAnalysisPage(TestingContext testingContext) : base(testingContext)
     {

--- a/TransactionProcessor.Mobile.UITests/Pages/TransactionsBillPaymentSelectOperatorPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/TransactionsBillPaymentSelectOperatorPage.cs
@@ -1,6 +1,7 @@
 ﻿using OpenQA.Selenium;
 using Shared.IntegrationTesting;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -12,8 +13,12 @@ public class TransactionsBillPaymentSelectOperatorPage : BasePage2
     }
 
     #region Properties
-
-    protected override String Trait => "SelectanOperator";
+    
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Select an Operator",
+        _ => "SelectanOperator"
+    };
 
     #endregion
 
@@ -49,7 +54,11 @@ public class TransactionsBillPaymentEnterAccountDetailsPage : BasePage2
         this.GetAccountButton = "GetAccountButton";
     }
 
-    protected override String Trait => "GetCustomerAccount";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Get Customer Account",
+        _ => "GetCustomerAccount"
+    };
 
     public async Task EnterCustomerAccountNumber(String customerAccountNumber)
     {
@@ -80,7 +89,11 @@ public class TransactionsBillPaymentEnterMeterDetailsPage : BasePage2
         this.GetMeterButton = "GetMeterButton";
     }
 
-    protected override String Trait => "GetMeter";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Get Meter",
+        _ => "GetMeter"
+    };
 
     public async Task EnterMeterNumber(String meterNumber)
     {
@@ -122,7 +135,11 @@ public class TransactionsBillPaymentMakeAPaymentPage : BasePage2
 
     }
 
-    protected override String Trait => "MakeBillPayment";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Make Bill Payment",
+        _ => "MakeBillPayment"
+    };
 
     public async Task EnterCustomerMobileNumber(String customerMobileNumber)
     {
@@ -195,7 +212,11 @@ public class TransactionsBillPaymentSuccessfulPaymentPage : BasePage2
 
     #region Properties
 
-    protected override String Trait => "BillPaymentSuccessful";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Bill Payment Successful",
+        _ => "BillPaymentSuccessful"
+    };
 
     public async Task ClickCompleteButton()
     {

--- a/TransactionProcessor.Mobile.UITests/Pages/TransactionsMobileTopupEnterTopupDetailsPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/TransactionsMobileTopupEnterTopupDetailsPage.cs
@@ -1,6 +1,7 @@
 ﻿using OpenQA.Selenium;
 using Shared.IntegrationTesting;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -20,7 +21,11 @@ public class TransactionsMobileTopupEnterTopupDetailsPage : BasePage2 {
 
     #region Properties
 
-    protected override String Trait => "EnterTopupDetails";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Enter Topup Details",
+        _ => "EnterTopupDetails"
+    };
 
     public async Task EnterCustomerMobileNumber(String customerMobileNumber) {
         IWebElement element = await this.WaitForElementByAccessibilityId(this.CustomerMobileNumberEntry);

--- a/TransactionProcessor.Mobile.UITests/Pages/TransactionsMobileTopupSelectOperatorPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/TransactionsMobileTopupSelectOperatorPage.cs
@@ -1,5 +1,6 @@
 ﻿using OpenQA.Selenium;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -11,8 +12,11 @@ public class TransactionsMobileTopupSelectOperatorPage : BasePage2
     }
 
     #region Properties
-
-    protected override String Trait => "SelectanOperator";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Select an Operator",
+        _ => "SelectanOperator"
+    };
 
     #endregion
 

--- a/TransactionProcessor.Mobile.UITests/Pages/TransactionsMobileTopupSelectProductPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/TransactionsMobileTopupSelectProductPage.cs
@@ -1,5 +1,6 @@
 ﻿using OpenQA.Selenium;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -10,7 +11,11 @@ public class TransactionsMobileTopupSelectProductPage : BasePage2 {
 
     #region Properties
 
-    protected override String Trait => "SelectaProduct";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Select a Product",
+        _ => "SelectaProduct"
+    };
 
     #endregion
 

--- a/TransactionProcessor.Mobile.UITests/Pages/TransactionsMobileTopupSuccessfulTopupPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/TransactionsMobileTopupSuccessfulTopupPage.cs
@@ -1,6 +1,7 @@
 ﻿using OpenQA.Selenium;
 using Shared.IntegrationTesting;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -14,8 +15,12 @@ public class TransactionsMobileTopupSuccessfulTopupPage : BasePage2 {
 
     #region Properties
 
-    protected override String Trait => "MobileTopupSuccessful";
-    
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Mobile Topup Successful",
+        _ => "MobileTopupSuccessful"
+    };
+
     public async Task ClickCompleteButton() {
         await Retry.For(async () => {
                             IWebElement element = await this.WaitForElementByAccessibilityId(this.CompleteButton);

--- a/TransactionProcessor.Mobile.UITests/Pages/TransactionsVoucherEnterVoucherIssueDetailsPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/TransactionsVoucherEnterVoucherIssueDetailsPage.cs
@@ -1,6 +1,7 @@
 ﻿using OpenQA.Selenium;
 using Shared.IntegrationTesting;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -24,7 +25,11 @@ public class TransactionsVoucherEnterVoucherIssueDetailsPage : BasePage2
 
     #region Properties
 
-    protected override String Trait => "EnterVoucherIssueDetails";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Enter Voucher Issue Details",
+        _ => "EnterVoucherIssueDetails"
+    };
 
     public async Task EnterRecipientMobileNumber(String recipientMobileNumber)
     {

--- a/TransactionProcessor.Mobile.UITests/Pages/TransactionsVoucherIssueSuccessfulTopupPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/TransactionsVoucherIssueSuccessfulTopupPage.cs
@@ -1,6 +1,7 @@
 ﻿using OpenQA.Selenium;
 using Shared.IntegrationTesting;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -16,7 +17,11 @@ public class TransactionsVoucherIssueSuccessfulTopupPage : BasePage2
 
     #region Properties
 
-    protected override String Trait => "VoucherIssueSuccessful";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Voucher Issue Successful",
+        _ => "VoucherIssueSuccessful"
+    };
 
     public async Task ClickCompleteButton()
     {

--- a/TransactionProcessor.Mobile.UITests/Pages/TransactionsVoucherSelectOperatorPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/TransactionsVoucherSelectOperatorPage.cs
@@ -1,5 +1,6 @@
 ﻿using OpenQA.Selenium;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -11,9 +12,11 @@ public class TransactionsVoucherSelectOperatorPage : BasePage2
     }
 
     #region Properties
-
-    protected override String Trait => "SelectanOperator";
-
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Select an Operator",
+        _ => "SelectanOperator"
+    };
     #endregion
 
     public async Task ClickOperatorButton(String operatorName)

--- a/TransactionProcessor.Mobile.UITests/Pages/TransactionsVoucherSelectProductPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/TransactionsVoucherSelectProductPage.cs
@@ -1,5 +1,6 @@
 ﻿using OpenQA.Selenium;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -12,7 +13,11 @@ public class TransactionsVoucherSelectProductPage : BasePage2
 
     #region Properties
 
-    protected override String Trait => "SelectaProduct";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "Select a Product",
+        _ => "SelectaProduct"
+    };
 
     #endregion
 

--- a/TransactionProcessor.Mobile.UITests/Pages/ViewLogsPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/ViewLogsPage.cs
@@ -1,4 +1,5 @@
 ﻿using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 
 namespace TransactionProcessor.Mobile.UITests.Pages;
 
@@ -7,5 +8,9 @@ public class ViewLogsPage : BasePage2{
         
     }
 
-    protected override String Trait => "ViewLogs";
+    protected override String Trait => AppiumDriverWrapper.MobileTestPlatform switch
+    {
+        MobileTestPlatform.iOS => "View Logs",
+        _ => "ViewLogs"
+    };
 }

--- a/TransactionProcessor.Mobile.UITests/Steps/SharedAppSteps.cs
+++ b/TransactionProcessor.Mobile.UITests/Steps/SharedAppSteps.cs
@@ -30,8 +30,10 @@ namespace TransactionProcessor.Mobile.UITests.Steps
 
         [Then(@"The application closes")]
         public void ThenTheApplicationCloses() {
-            AppState state = AppiumDriverWrapper.Driver.GetAppState("com.transactionprocessor.mobile");
-            state.ShouldBe(AppState.NotRunning);
+            if (AppiumDriverWrapper.MobileTestPlatform != MobileTestPlatform.iOS) {
+                AppState state = AppiumDriverWrapper.Driver.GetAppState("com.transactionprocessor.mobile");
+                state.ShouldBe(AppState.NotRunning);
+            }
         }
 
         [When(@"I click yes")]

--- a/TransactionProcessor.Mobile.UITests/Steps/TransactionsSteps.cs
+++ b/TransactionProcessor.Mobile.UITests/Steps/TransactionsSteps.cs
@@ -2,6 +2,7 @@
 using Shared.IntegrationTesting;
 using Shouldly;
 using TransactionProcessor.Mobile.UITests.Common;
+using TransactionProcessor.Mobile.UITests.Drivers;
 using TransactionProcessor.Mobile.UITests.Pages;
 
 namespace TransactionProcessor.Mobile.UITests.Steps;
@@ -129,7 +130,10 @@ public class TransactionsSteps{
 
     [When(@"I tap on the '([^']*)' button")]
     public async Task WhenITapOnTheButton(String operatorName) {
-        operatorName = operatorName.Replace(" ", "");
+        if (AppiumDriverWrapper.MobileTestPlatform != MobileTestPlatform.iOS) {
+            operatorName = operatorName.Replace(" ", "");
+        }
+
         Task t = this.operatorType switch{
             OperatorType.MobileTopup => this.transactionsMobileTopupSelectOperatorPage.ClickOperatorButton(operatorName),
             OperatorType.Voucher => this.transactionsVoucherSelectOperatorPage.ClickOperatorButton(operatorName),
@@ -146,7 +150,10 @@ public class TransactionsSteps{
 
     [When(@"I tap on the '([^']*)' product button")]
     public async Task WhenITapOnTheProductButton(String productText){
-        productText= productText.Replace(" ", "");
+        if (AppiumDriverWrapper.MobileTestPlatform != MobileTestPlatform.iOS) {
+            productText = productText.Replace(" ", "");
+        }
+
         Task t = this.operatorType switch{
             OperatorType.MobileTopup => this.transactionsMobileTopupSelectProductPage.ClickProductButton(productText),
             OperatorType.Voucher => this.transactionsVoucherSelectProductPage.ClickProductButton(productText),

--- a/TransactionProcessor.Mobile.sln
+++ b/TransactionProcessor.Mobile.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransactionProcessor.Mobile
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransactionProcessor.Mobile.UITests", "TransactionProcessor.Mobile.UITests\TransactionProcessor.Mobile.UITests.csproj", "{E892CDC5-7DDF-4A0A-B8DB-AAC2DE758E56}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestCategoryLister", "TestCategoryLister\TestCategoryLister.csproj", "{A9557544-11B0-4718-A52D-8D513C9DD619}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,7 @@ Global
 		{6BE81803-4FDB-4900-8ED4-971A6AD4140D}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{6BE81803-4FDB-4900-8ED4-971A6AD4140D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6BE81803-4FDB-4900-8ED4-971A6AD4140D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BE81803-4FDB-4900-8ED4-971A6AD4140D}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{93C672C9-E5CA-4AE5-A190-9FF15B28F318}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{93C672C9-E5CA-4AE5-A190-9FF15B28F318}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{93C672C9-E5CA-4AE5-A190-9FF15B28F318}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -38,6 +41,10 @@ Global
 		{E892CDC5-7DDF-4A0A-B8DB-AAC2DE758E56}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E892CDC5-7DDF-4A0A-B8DB-AAC2DE758E56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E892CDC5-7DDF-4A0A-B8DB-AAC2DE758E56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9557544-11B0-4718-A52D-8D513C9DD619}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9557544-11B0-4718-A52D-8D513C9DD619}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9557544-11B0-4718-A52D-8D513C9DD619}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9557544-11B0-4718-A52D-8D513C9DD619}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -47,6 +54,7 @@ Global
 		{93C672C9-E5CA-4AE5-A190-9FF15B28F318} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{327D1FDB-E953-4501-9DED-193EF75148E1} = {7AB22349-8BB9-41D3-A40F-268DFC30FD0C}
 		{E892CDC5-7DDF-4A0A-B8DB-AAC2DE758E56} = {7AB22349-8BB9-41D3-A40F-268DFC30FD0C}
+		{A9557544-11B0-4718-A52D-8D513C9DD619} = {7AB22349-8BB9-41D3-A40F-268DFC30FD0C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4A92260C-922A-4553-A4DE-94C3BE3BA20F}

--- a/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
+++ b/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
@@ -175,7 +175,7 @@
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.80" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
 		<PackageReference Include="banditoth.MAUI.DeviceId" Version="1.0.2" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="12.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="11.5.0" />
 		<PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.0-rc2" />
 	</ItemGroup>
 

--- a/TransactionProcessor.Mobile/UIServices/DialogService.cs
+++ b/TransactionProcessor.Mobile/UIServices/DialogService.cs
@@ -21,6 +21,7 @@ namespace TransactionMobile.Maui.UIServices
                                               String message,
                                               String acceptString,
                                               String cancelString) {
+            await Task.Delay(200); // allow view to fully appear
             return await Application.Current.MainPage.DisplayAlert(title, message, acceptString, cancelString);
         }
 


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow named "Build and Run iOS Navigation Tests" in the `ios_navigation_tests.yml` file. The workflow is triggered on pull requests to the `main` branch and runs on macOS 14. It sets up the environment for testing an iOS application by installing Node.js, .NET, Appium, and necessary workloads. The workflow also creates and boots an iOS simulator, restores the MAUI app, builds the code, and executes the iOS navigation tests. Additionally, it uploads Appium logs in case of test failures.

closes #209 