### PR TITLE
Refactor operator retrieval to use GetProductOperators

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/TestData.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/TestData.cs
@@ -154,6 +154,11 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests
                                                                            TestData.Operator3Product_200KES
                                                                        };
 
+        public static List<ContractOperatorModel> ContractOperatorList = new List<ContractOperatorModel>
+                                                                       {
+                                                                           ContractOperatorModel
+                                                                       };
+
         public static List<ContractProductModel> ContractProductListEmpty = new List<ContractProductModel>();
 
         public static ContractOperatorModel ContractOperatorModel = new ContractOperatorModel

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Transactions/BillPayment/BillPaymentSelectOperatorPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Transactions/BillPayment/BillPaymentSelectOperatorPageViewModelTests.cs
@@ -47,26 +47,26 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ViewModelTests.Transac
         [Fact]
         public async Task BillPaymentSelectOperatorPageViewModel_Initialise_IsInitialised()
         {
-            this.Mediator.Setup(m => m.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
+            this.Mediator.Setup(m => m.Send(It.IsAny<GetProductOperators>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractOperatorList));
 
             await this.ViewModel.Initialise(CancellationToken.None);
-            this.Mediator.Verify(x => x.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+            this.Mediator.Verify(x => x.Send(It.IsAny<GetProductOperators>(), It.IsAny<CancellationToken>()), Times.Once);
 
-            this.ViewModel.Operators.Count.ShouldBe(3);
+            this.ViewModel.Operators.Count.ShouldBe(1);
         }
 
         [Fact]
         public async Task BillPaymentSelectOperatorPageViewModel_OperatorSelectedCommand_Execute_IsExecuted()
         {
-            this.Mediator.Setup(m => m.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
+            this.Mediator.Setup(m => m.Send(It.IsAny<GetProductOperators>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractOperatorList));
 
             await this.ViewModel.Initialise(CancellationToken.None);
 
-            this.ViewModel.Operators.Count.ShouldBe(3);
+            this.ViewModel.Operators.Count.ShouldBe(1);
 
             ItemSelected<ContractOperatorModel> selectedContractOperator = new ItemSelected<ContractOperatorModel>
                                                                            {
-                                                                               SelectedItemIndex = 1,
+                                                                               SelectedItemIndex = 0,
                                                                                SelectedItem = TestData.ContractOperatorModel
                                                                            };
 

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Transactions/MobileTopup/MobileTopupSelectOperatorPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Transactions/MobileTopup/MobileTopupSelectOperatorPageViewModelTests.cs
@@ -46,22 +46,22 @@ public class MobileTopupSelectOperatorPageViewModelTests
     [Fact]
     public async Task MobileTopupSelectOperatorPageViewModel_Initialise_IsInitialised()
     {
-        this.Mediator.Setup(m => m.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
-        
-        await this.ViewModel.Initialise(CancellationToken.None);
-        this.Mediator.Verify(x => x.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+        this.Mediator.Setup(m => m.Send(It.IsAny<GetProductOperators>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractOperatorList));
 
-        this.ViewModel.Operators.Count.ShouldBe(3);
+        await this.ViewModel.Initialise(CancellationToken.None);
+        this.Mediator.Verify(x => x.Send(It.IsAny<GetProductOperators>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        this.ViewModel.Operators.Count.ShouldBe(1);
     }
 
     [Fact]
     public async Task MobileTopupSelectOperatorPageViewModel_OperatorSelectedCommand_Execute_IsExecuted()
     {
-        this.Mediator.Setup(m => m.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
-        
+        this.Mediator.Setup(m => m.Send(It.IsAny<GetProductOperators>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractOperatorList));
+
         await this.ViewModel.Initialise(CancellationToken.None);
 
-        this.ViewModel.Operators.Count.ShouldBe(3);
+        this.ViewModel.Operators.Count.ShouldBe(1);
 
         ItemSelected<ContractOperatorModel> selectedContractOperator = new ItemSelected<ContractOperatorModel>
                                                                        {

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Transactions/Voucher/VoucherSelectOperatorPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Transactions/Voucher/VoucherSelectOperatorPageViewModelTests.cs
@@ -42,23 +42,22 @@ public class VoucherSelectOperatorPageViewModelTests
     [Fact]
     public async Task VoucherSelectOperatorPageViewModel_Initialise_IsInitialised()
     {
-        this.Mediator.Setup(m => m.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
-        
+        this.Mediator.Setup(m => m.Send(It.IsAny<GetProductOperators>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractOperatorList));
 
         await this.ViewModel.Initialise(CancellationToken.None);
-        this.Mediator.Verify(x => x.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+        this.Mediator.Verify(x => x.Send(It.IsAny<GetProductOperators>(), It.IsAny<CancellationToken>()), Times.Once);
 
-        this.ViewModel.Operators.Count.ShouldBe(3);
+        this.ViewModel.Operators.Count.ShouldBe(1);
     }
 
     [Fact]
     public async Task VoucherSelectOperatorPageViewModel_OperatorSelectedCommand_Execute_IsExecuted()
     {
-        this.Mediator.Setup(m => m.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
-        
+        this.Mediator.Setup(m => m.Send(It.IsAny<GetProductOperators>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractOperatorList));
+
         await this.ViewModel.Initialise(CancellationToken.None);
 
-        this.ViewModel.Operators.Count.ShouldBe(3);
+        this.ViewModel.Operators.Count.ShouldBe(1);
 
         ItemSelected<ContractOperatorModel> selectedContractOperator = new ItemSelected<ContractOperatorModel>
                                                                        {

--- a/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/MerchantRequestHandler.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/MerchantRequestHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Shared.Results;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.Requests;
@@ -8,7 +9,8 @@ namespace TransactionProcessor.Mobile.BusinessLogic.RequestHandlers;
 
 public class MerchantRequestHandler : IRequestHandler<GetContractProductsRequest, Result<List<ContractProductModel>>>,
                                       IRequestHandler<GetMerchantBalanceRequest, Result<Decimal>>,
-                                      IRequestHandler<GetMerchantDetailsRequest, Result<MerchantDetailsModel>>
+                                      IRequestHandler<GetMerchantDetailsRequest, Result<MerchantDetailsModel>>,
+                                      IRequestHandler<GetProductOperators, Result<List<ContractOperatorModel>>>
 {
     #region Fields
 
@@ -74,4 +76,43 @@ public class MerchantRequestHandler : IRequestHandler<GetContractProductsRequest
     }
 
     #endregion
+
+    public async Task<Result<List<ContractOperatorModel>>> Handle(GetProductOperators request,
+                                                                  CancellationToken cancellationToken) {
+        List<ContractProductModel> products = this.ApplicationCache.GetContractProducts();
+
+        Boolean useTrainingMode = this.ApplicationCache.GetUseTrainingMode();
+        IMerchantService merchantService = this.MerchantServiceResolver(useTrainingMode);
+
+        if (products == null || products.Any() == false)
+        {
+            Result<List<ContractProductModel>> getProductsResult = await merchantService.GetContractProducts(cancellationToken);
+            if (getProductsResult.IsSuccess)
+            {
+                products = getProductsResult.Data;
+
+                if (request.ProductType.HasValue)
+                {
+                    products = products.Where(p => p.ProductType == request.ProductType).ToList();
+                }
+            }
+            
+            return ResultHelpers.CreateFailure(getProductsResult);
+        }
+
+        List<ContractOperatorModel> operators = products.GroupBy(c => new
+        {
+            c.OperatorName,
+            c.OperatorId,
+            c.OperatorIdentfier
+        }).Select(g => new ContractOperatorModel
+        {
+            OperatorId = g.Key.OperatorId,
+            OperatorName = g.Key.OperatorName,
+            OperatorIdentfier = g.Key.OperatorIdentfier
+        }).ToList();
+
+        return Result.Success(operators);
+
+    }
 }

--- a/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/MerchantRequestHandler.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/MerchantRequestHandler.cs
@@ -87,17 +87,16 @@ public class MerchantRequestHandler : IRequestHandler<GetContractProductsRequest
         if (products == null || products.Any() == false)
         {
             Result<List<ContractProductModel>> getProductsResult = await merchantService.GetContractProducts(cancellationToken);
-            if (getProductsResult.IsSuccess)
-            {
-                products = getProductsResult.Data;
-
-                if (request.ProductType.HasValue)
-                {
-                    products = products.Where(p => p.ProductType == request.ProductType).ToList();
-                }
+            if (getProductsResult.IsFailed) {
+                return ResultHelpers.CreateFailure(getProductsResult);
             }
-            
-            return ResultHelpers.CreateFailure(getProductsResult);
+
+            products = getProductsResult.Data;
+
+            if (request.ProductType.HasValue)
+            {
+                products = products.Where(p => p.ProductType == request.ProductType).ToList();
+            }
         }
 
         List<ContractOperatorModel> operators = products.GroupBy(c => new

--- a/TransactionProcessor.Mobile.BusinessLogic/Requests/GetContractProductsRequest.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Requests/GetContractProductsRequest.cs
@@ -28,3 +28,5 @@ public class GetContractProductsRequest : IRequest<Result<List<ContractProductMo
 
     #endregion
 }
+
+public record GetProductOperators(ProductType? ProductType) : IRequest<Result<List<ContractOperatorModel>>>;

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Transactions/BillPaymentSelectOperatorPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Transactions/BillPaymentSelectOperatorPageViewModel.cs
@@ -45,26 +45,14 @@ public partial class BillPaymentSelectOperatorPageViewModel : ExtendedBaseViewMo
 
     public async Task Initialise(CancellationToken cancellationToken)
     {
-        GetContractProductsRequest request = GetContractProductsRequest.Create(ProductType.BillPayment);
-
-        Result<List<ContractProductModel>> productsresult = await this.Mediator.Send(request, cancellationToken);
-        // TODO: Handle the failure result
-        List<ContractProductModel> products = productsresult.Data;
-
-        // TODO: Should this logic live in the Reqest handler ???
-        List<ContractOperatorModel> operators = products.GroupBy(c => new
-                                                                      {
-                                                                          c.OperatorName,
-                                                                          c.OperatorId,
-                                                                          c.OperatorIdentfier
-                                                                      }).Select(g => new ContractOperatorModel
-                                                                                     {
-                                                                                         OperatorId = g.Key.OperatorId,
-                                                                                         OperatorName = g.Key.OperatorName,
-                                                                                         OperatorIdentfier = g.Key.OperatorIdentfier
-                                                                                     }).ToList();
-
-        this.Operators = operators;
+        GetProductOperators request = new GetProductOperators(ProductType.BillPayment);
+        Result<List<ContractOperatorModel>> operatorsResult = await this.Mediator.Send(request, cancellationToken);
+        if (operatorsResult.IsFailed)
+        {
+            await this.DialogService.ShowWarningToast("Unable to load operators. Please try again later.", cancellationToken: cancellationToken);
+            return;
+        }
+        this.Operators = operatorsResult.Data;
     }
 
     [RelayCommand]

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Transactions/MobileTopupSelectOperatorPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Transactions/MobileTopupSelectOperatorPageViewModel.cs
@@ -43,25 +43,14 @@ public partial class MobileTopupSelectOperatorPageViewModel : ExtendedBaseViewMo
 
     public async Task Initialise(CancellationToken cancellationToken)
     {
-        GetContractProductsRequest request = GetContractProductsRequest.Create(ProductType.MobileTopup);
-
-        Result<List<ContractProductModel>> productsresult = await this.Mediator.Send(request, cancellationToken);
-        List<ContractProductModel> products = productsresult.Data;
-
-        // TODO: Should this logic live in the Request handler ???
-        List<ContractOperatorModel> operators = products.GroupBy(c => new
-            {
-                c.OperatorName,
-                c.OperatorId,
-                c.OperatorIdentfier
-            }).Select(g => new ContractOperatorModel
-                           {
-                               OperatorId = g.Key.OperatorId,
-                               OperatorName = g.Key.OperatorName,
-                               OperatorIdentfier = g.Key.OperatorIdentfier
-                           }).ToList();
-
-        this.Operators = operators;
+        GetProductOperators request = new GetProductOperators(ProductType.MobileTopup);
+        Result<List<ContractOperatorModel>> operatorsResult = await this.Mediator.Send(request, cancellationToken);
+        if (operatorsResult.IsFailed)
+        {
+            await this.DialogService.ShowWarningToast("Unable to load operators. Please try again later.", cancellationToken: cancellationToken);
+            return;
+        }
+        this.Operators = operatorsResult.Data;
     }
 
     [RelayCommand]

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Transactions/VoucherSelectOperatorPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Transactions/VoucherSelectOperatorPageViewModel.cs
@@ -1,7 +1,8 @@
-﻿using System.Windows.Input;
-using CommunityToolkit.Mvvm.Input;
+﻿using CommunityToolkit.Mvvm.Input;
 using MediatR;
 using MvvmHelpers.Commands;
+using SimpleResults;
+using System.Windows.Input;
 using TransactionProcessor.Mobile.BusinessLogic.Common;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
@@ -43,25 +44,14 @@ public partial class VoucherSelectOperatorPageViewModel : ExtendedBaseViewModel
 
     public async Task Initialise(CancellationToken cancellationToken)
     {
-        GetContractProductsRequest request = GetContractProductsRequest.Create(ProductType.Voucher);
-
-        var productsresult = await this.Mediator.Send(request, cancellationToken);
-        List<ContractProductModel> products = productsresult.Data;
-
-        // TODO: Should this logic live in the Reqest handler ???
-        List<ContractOperatorModel> operators = products.GroupBy(c => new
-            {
-                c.OperatorName,
-                c.OperatorId,
-                c.OperatorIdentfier
-            }).Select(g => new ContractOperatorModel
-                           {
-                               OperatorId = g.Key.OperatorId,
-                               OperatorName = g.Key.OperatorName,
-                               OperatorIdentfier = g.Key.OperatorIdentfier
-                           }).ToList();
-
-        this.Operators = operators;
+        GetProductOperators request = new GetProductOperators(ProductType.Voucher);
+        Result<List<ContractOperatorModel>> operatorsResult = await this.Mediator.Send(request, cancellationToken);
+        if (operatorsResult.IsFailed)
+        {
+            await this.DialogService.ShowWarningToast("Unable to load operators. Please try again later.", cancellationToken: cancellationToken);
+            return;
+        }
+        this.Operators = operatorsResult.Data;
     }
 
     [RelayCommand]

--- a/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
+++ b/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
@@ -183,29 +183,31 @@ namespace TransactionProcessor.Mobile.Extensions {
         }
 
         public static MauiAppBuilder ConfigureRequestHandlers(this MauiAppBuilder builder) {
-            builder.Services.AddSingleton<MediatRServiceConfiguration>();
-            builder.Services.AddSingleton<ISender, Mediator>();
-            builder.Services.AddSingleton<IPublisher, Mediator>();
-            builder.Services.AddSingleton<IMediator, Mediator>();
-            builder.Services.AddSingleton<IRequestHandler<GetConfigurationRequest, Result<Configuration>>, LoginRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<LoginRequest, Result<TokenResponseModel>>, LoginRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<RefreshTokenRequest, Result<TokenResponseModel>>, LoginRequestHandler>();
+            //builder.Services.AddSingleton<MediatRServiceConfiguration>();
+            //builder.Services.AddSingleton<ISender, Mediator>();
+            //builder.Services.AddSingleton<IPublisher, Mediator>();
+            //builder.Services.AddSingleton<IMediator, Mediator>();
+            builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(LoginRequestHandler).Assembly));
+            //builder.Services.AddSingleton<IRequestHandler<GetConfigurationRequest, Result<Configuration>>, LoginRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<LoginRequest, Result<TokenResponseModel>>, LoginRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<RefreshTokenRequest, Result<TokenResponseModel>>, LoginRequestHandler>();
 
-            builder.Services.AddSingleton<IRequestHandler<GetContractProductsRequest, Result<List<ContractProductModel>>>, MerchantRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<GetMerchantBalanceRequest, Result<Decimal>>, MerchantRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<GetMerchantDetailsRequest, Result<MerchantDetailsModel>>, MerchantRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<GetContractProductsRequest, Result<List<ContractProductModel>>>, MerchantRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<GetProductOperators, Result<List<ContractOperatorModel>>>, MerchantRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<GetMerchantBalanceRequest, Result<Decimal>>, MerchantRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<GetMerchantDetailsRequest, Result<MerchantDetailsModel>>, MerchantRequestHandler>();
 
-            builder.Services.AddSingleton<IRequestHandler<PerformMobileTopupRequest, Result<PerformMobileTopupResponseModel>>, TransactionRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<LogonTransactionRequest, Result<PerformLogonResponseModel>>, TransactionRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<PerformVoucherIssueRequest, Result<PerformVoucherIssueResponseModel>>, TransactionRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<PerformReconciliationRequest, Result<PerformReconciliationResponseModel>>, TransactionRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentGetAccountRequest, Result<PerformBillPaymentGetAccountResponseModel>>, TransactionRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentGetMeterRequest, Result<PerformBillPaymentGetMeterResponseModel>>, TransactionRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentMakePostPaymentRequest, Result<PerformBillPaymentMakePaymentResponseModel>>, TransactionRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentMakePrePaymentRequest, Result<PerformBillPaymentMakePaymentResponseModel>>, TransactionRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<PerformMobileTopupRequest, Result<PerformMobileTopupResponseModel>>, TransactionRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<LogonTransactionRequest, Result<PerformLogonResponseModel>>, TransactionRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<PerformVoucherIssueRequest, Result<PerformVoucherIssueResponseModel>>, TransactionRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<PerformReconciliationRequest, Result<PerformReconciliationResponseModel>>, TransactionRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentGetAccountRequest, Result<PerformBillPaymentGetAccountResponseModel>>, TransactionRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentGetMeterRequest, Result<PerformBillPaymentGetMeterResponseModel>>, TransactionRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentMakePostPaymentRequest, Result<PerformBillPaymentMakePaymentResponseModel>>, TransactionRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentMakePrePaymentRequest, Result<PerformBillPaymentMakePaymentResponseModel>>, TransactionRequestHandler>();
 
-            builder.Services.AddSingleton<IRequestHandler<UploadLogsRequest, Boolean>, SupportRequestHandler>();
-            builder.Services.AddSingleton<IRequestHandler<ViewLogsRequest, List<LogMessage>>, SupportRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<UploadLogsRequest, Boolean>, SupportRequestHandler>();
+            //builder.Services.AddSingleton<IRequestHandler<ViewLogsRequest, List<LogMessage>>, SupportRequestHandler>();
 
             return builder;
         }


### PR DESCRIPTION
Moved operator grouping logic from ViewModels to a new GetProductOperators request/handler in MerchantRequestHandler. Updated ViewModels and tests to use the new request. Switched DI to MediatR assembly scanning. Added error handling for operator loading failures and cleaned up code.

closes #518 
closes #517 