### PR TITLE
Make log upload batch size configurable via settings

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/RequestHandlerTests/SupportRequestHandlerTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/RequestHandlerTests/SupportRequestHandlerTests.cs
@@ -1,9 +1,12 @@
 ﻿using Moq;
 using Shouldly;
 using TransactionProcessor.Mobile.BusinessLogic.Database;
+using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.RequestHandlers;
 using TransactionProcessor.Mobile.BusinessLogic.Requests;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
+using LogLevel = TransactionProcessor.Mobile.BusinessLogic.Database.LogLevel;
+using LogMessage = TransactionProcessor.Mobile.BusinessLogic.Database.LogMessage;
 
 namespace TransactionProcessor.Mobile.BusinessLogic.Tests.RequestHandlerTests;
 
@@ -22,7 +25,7 @@ public class SupportRequestHandlerTests
         Mock<IDatabaseContext> databaseContext = new Mock<IDatabaseContext>();
         databaseContext.Setup(d => d.GetLogMessages(It.IsAny<Int32>(), It.IsAny<Boolean>())).ReturnsAsync(new List<Database.LogMessage>());
         Mock<IApplicationCache> applicationCache = new Mock<IApplicationCache>();
-
+        applicationCache.Setup(s => s.GetConfiguration()).Returns(new Configuration());
         SupportRequestHandler handler = new SupportRequestHandler(configurationServiceResolver, databaseContext.Object, applicationCache.Object);
 
         UploadLogsRequest request = UploadLogsRequest.Create(TestData.DeviceIdentifier);
@@ -56,6 +59,7 @@ public class SupportRequestHandlerTests
         }).ReturnsAsync(new List<Database.LogMessage>());
 
         Mock<IApplicationCache> applicationCache = new Mock<IApplicationCache>();
+        applicationCache.Setup(s => s.GetConfiguration()).Returns(new Configuration());
 
         SupportRequestHandler handler = new SupportRequestHandler(configurationServiceResolver, databaseContext.Object, applicationCache.Object);
 
@@ -98,6 +102,7 @@ public class SupportRequestHandlerTests
         }).ReturnsAsync(new List<Database.LogMessage>());
 
         Mock<IApplicationCache> applicationCache = new Mock<IApplicationCache>();
+        applicationCache.Setup(s => s.GetConfiguration()).Returns(new Configuration());
 
         SupportRequestHandler handler = new SupportRequestHandler(configurationServiceResolver, databaseContext.Object, applicationCache.Object);
 

--- a/TransactionProcessor.Mobile.BusinessLogic/Models/TokenResponseModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Models/TokenResponseModel.cs
@@ -38,5 +38,6 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Models
         public Boolean EnableAutoUpdates { get; set; }
 
         public Boolean ShowDebugMessages { get; set; }
+        public Int32? LogMessageBatchSize { get; set; }
     }
 }

--- a/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/SupportRequestHandler.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/SupportRequestHandler.cs
@@ -31,7 +31,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.RequestHandlers
             while (true) {
                 IConfigurationService configurationService = this.ConfigurationServiceResolver(useTrainingMode);
 
-                List<LogMessage> logEntries = await this.DatabaseContext.GetLogMessages(configuration.LogMessageBatchSize.GetValueOrDefault(10), useTrainingMode); // TODO: Configurable batch size
+                List<LogMessage> logEntries = await this.DatabaseContext.GetLogMessages(configuration.LogMessageBatchSize.GetValueOrDefault(10), useTrainingMode);
 
                 if (logEntries.Any() == false) {
                     break;

--- a/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/SupportRequestHandler.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/SupportRequestHandler.cs
@@ -1,7 +1,9 @@
 ﻿using MediatR;
 using TransactionProcessor.Mobile.BusinessLogic.Database;
+using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.Requests;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
+using LogMessage = TransactionProcessor.Mobile.BusinessLogic.Database.LogMessage;
 
 namespace TransactionProcessor.Mobile.BusinessLogic.RequestHandlers
 {
@@ -25,20 +27,19 @@ namespace TransactionProcessor.Mobile.BusinessLogic.RequestHandlers
         public async Task<Boolean> Handle(UploadLogsRequest request, CancellationToken cancellationToken)
         {
             Boolean useTrainingMode = this.ApplicationCache.GetUseTrainingMode();
+            Configuration configuration = this.ApplicationCache.GetConfiguration();
+            while (true) {
+                IConfigurationService configurationService = this.ConfigurationServiceResolver(useTrainingMode);
 
-            while (true)
-            {
-                List<LogMessage> logEntries = await this.DatabaseContext.GetLogMessages(10, useTrainingMode); // TODO: Configurable batch size
+                List<LogMessage> logEntries = await this.DatabaseContext.GetLogMessages(configuration.LogMessageBatchSize.GetValueOrDefault(10), useTrainingMode); // TODO: Configurable batch size
 
-                if (logEntries.Any() == false)
-                {
+                if (logEntries.Any() == false) {
                     break;
                 }
 
-                List<Models.LogMessage> logMessageModels = new List<Models.LogMessage>();
+                List<Models.LogMessage> logMessageModels = new();
 
-                logEntries.ForEach(l => logMessageModels.Add(new Models.LogMessage
-                {
+                logEntries.ForEach(l => logMessageModels.Add(new Models.LogMessage {
                     LogLevel = Enum.Parse<Models.LogLevel>(l.LogLevel),
                     LogLevelString = l.LogLevel,
                     Message = l.Message,
@@ -46,7 +47,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.RequestHandlers
                     Id = l.Id
                 }));
 
-                IConfigurationService configurationService = this.ConfigurationServiceResolver(useTrainingMode);
+
                 await configurationService.PostDiagnosticLogs(request.DeviceIdentifier, logMessageModels, CancellationToken.None);
 
                 // Clear the logs that have been uploaded
@@ -60,9 +61,9 @@ namespace TransactionProcessor.Mobile.BusinessLogic.RequestHandlers
                                                     CancellationToken cancellationToken) {
             Boolean useTrainingMode = this.ApplicationCache.GetUseTrainingMode();
 
-            List<LogMessage> logEntries = await this.DatabaseContext.GetLogMessages(50, useTrainingMode); // TODO: Configurable batch size
+            List<LogMessage> logEntries = await this.DatabaseContext.GetLogMessages(50, useTrainingMode);
 
-            List<Models.LogMessage> logMessageModels = new List<Models.LogMessage>();
+            List<Models.LogMessage> logMessageModels = new();
 
             logEntries.ForEach(l => logMessageModels.Add(new Models.LogMessage {
                                                                                    LogLevel = Enum.Parse<Models.LogLevel>(l.LogLevel),

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
@@ -81,6 +81,7 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
                 SecurityServiceUri = apiResponse.HostAddresses.Single(h => h.ServiceType == ServiceType.Security).Uri,
                 TransactionProcessorAclUri =
                     apiResponse.HostAddresses.Single(h => h.ServiceType == ServiceType.TransactionProcessorAcl).Uri,
+                LogMessageBatchSize = apiResponse.LogMessageBatchSize.GetValueOrDefault(),
             };
 
             Logger.LogDebug($"About to xlate log level");

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/DataTransferObjects/ConfigurationResponse.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/DataTransferObjects/ConfigurationResponse.cs
@@ -19,4 +19,6 @@ public class ConfigurationResponse
     public string Id { get; set; }
 
     public LoggingLevel LogLevel { get; set; }
+
+    public Int32? LogMessageBatchSize { get; set; }
 }


### PR DESCRIPTION
Added optional LogMessageBatchSize property to configuration models and API responses. Updated log upload logic to use this configurable batch size instead of a hardcoded value, defaulting to 10 if not set. Refactored log message model list creation for clarity. This enhances flexibility and maintainability of log uploads.

closes #516 