### PR TITLE
Handle missing merchant details with fetch and cache

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/MyAccount/MyAccountContactPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/MyAccount/MyAccountContactPageViewModelTests.cs
@@ -1,4 +1,5 @@
-﻿using Moq;
+﻿using MediatR;
+using Moq;
 using Shouldly;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
@@ -19,6 +20,7 @@ public class MyAccountContactPageViewModelTests
     private readonly MyAccountContactPageViewModel ViewModel;
 
     private readonly Mock<IDeviceService> DeviceService;
+    private readonly Mock<IMediator> Mediator;
 
     public MyAccountContactPageViewModelTests() {
         this.NavigationService = new Mock<INavigationService>();
@@ -26,10 +28,13 @@ public class MyAccountContactPageViewModelTests
         this.NavigationParameterService = new Mock<INavigationParameterService>();
         this.DialogService = new Mock<IDialogService>();
         this.DeviceService = new Mock<IDeviceService>();
+        this.Mediator = new Mock<IMediator>();
+
         this.ViewModel = new MyAccountContactPageViewModel(this.NavigationService.Object,
                                                            this.ApplicationCache.Object,
                                                            this.DialogService.Object, this.DeviceService.Object,
-                                                           this.NavigationParameterService.Object);
+                                                           this.NavigationParameterService.Object,
+                                                           this.Mediator.Object);
     }
 
     [Fact]

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/MyAccount/MyAccountAddressPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/MyAccount/MyAccountAddressPageViewModel.cs
@@ -1,5 +1,9 @@
 ﻿using MediatR;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Requests;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
 
@@ -42,7 +46,28 @@ public class MyAccountAddressPageViewModel : ExtendedBaseViewModel
     public async Task Initialise(CancellationToken cancellationToken) {
         MerchantDetailsModel merchantDetails = this.ApplicationCache.GetMerchantDetails();
 
-        // TODO: handle a null
+        if (merchantDetails == null) {
+            GetMerchantDetailsRequest request = GetMerchantDetailsRequest.Create();
+
+            Result<MerchantDetailsModel> merchantDetailsResult = await this.Mediator.Send(request, cancellationToken);
+            if (merchantDetailsResult.IsFailed) {
+                await this.DialogService.ShowWarningToast("Unable to load merchant details. Please try again later.", cancellationToken: cancellationToken);
+                return;
+            }
+
+            DateTime expirationTime = DateTime.Now.AddMinutes(60);
+            CancellationChangeToken expirationToken = new(new CancellationTokenSource(TimeSpan.FromMinutes(60)).Token);
+            MemoryCacheEntryOptions cacheEntryOptions = new MemoryCacheEntryOptions()
+                // Pin to cache.
+                .SetPriority(CacheItemPriority.NeverRemove)
+                // Set the actual expiration time
+                .SetAbsoluteExpiration(expirationTime)
+                // Force eviction to run
+                .AddExpirationToken(expirationToken);
+
+            this.ApplicationCache.SetMerchantDetails(merchantDetailsResult.Data, cacheEntryOptions);
+            merchantDetails = this.ApplicationCache.GetMerchantDetails();
+        }
 
         this.Address = merchantDetails.Address;
     }

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/MyAccount/MyAccountContactPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/MyAccount/MyAccountContactPageViewModel.cs
@@ -1,4 +1,9 @@
-﻿using TransactionProcessor.Mobile.BusinessLogic.Models;
+﻿using MediatR;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+using SimpleResults;
+using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Requests;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
 
@@ -6,6 +11,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.MyAccount;
 
 public class MyAccountContactPageViewModel : ExtendedBaseViewModel
 {
+    private readonly IMediator Mediator;
     private ContactModel contact;
 
     public ContactModel Contact {
@@ -19,17 +25,43 @@ public class MyAccountContactPageViewModel : ExtendedBaseViewModel
                                          IApplicationCache applicationCache,
                                          IDialogService dialogService,
                                          IDeviceService deviceService,
-                                         INavigationParameterService navigationParameterService) : base(applicationCache, dialogService, navigationService, deviceService, navigationParameterService) {
+                                         INavigationParameterService navigationParameterService,
+                                         IMediator mediator) : base(applicationCache, dialogService, navigationService, deviceService, navigationParameterService) {
+        this.Mediator = mediator;
         this.Title = "My Contacts";
     }
 
 
     #endregion
 
-    public async Task Initialise(CancellationToken none) {
+    public async Task Initialise(CancellationToken cancellationToken) {
         MerchantDetailsModel merchantDetails = this.ApplicationCache.GetMerchantDetails();
 
-        // TODO: handle a null
+        if (merchantDetails == null)
+        {
+            GetMerchantDetailsRequest request = GetMerchantDetailsRequest.Create();
+
+            Result<MerchantDetailsModel> merchantDetailsResult = await this.Mediator.Send(request, cancellationToken);
+            if (merchantDetailsResult.IsFailed)
+            {
+                await this.DialogService.ShowWarningToast("Unable to load merchant details. Please try again later.", cancellationToken: cancellationToken);
+                return;
+            }
+
+            DateTime expirationTime = DateTime.Now.AddMinutes(60);
+            CancellationChangeToken expirationToken = new(new CancellationTokenSource(TimeSpan.FromMinutes(60)).Token);
+            MemoryCacheEntryOptions cacheEntryOptions = new MemoryCacheEntryOptions()
+                // Pin to cache.
+                .SetPriority(CacheItemPriority.NeverRemove)
+                // Set the actual expiration time
+                .SetAbsoluteExpiration(expirationTime)
+                // Force eviction to run
+                .AddExpirationToken(expirationToken);
+
+            this.ApplicationCache.SetMerchantDetails(merchantDetailsResult.Data, cacheEntryOptions);
+            merchantDetails = this.ApplicationCache.GetMerchantDetails();
+        }
+
         this.Contact = merchantDetails.Contact;
     }
 }


### PR DESCRIPTION
Add logic to fetch merchant details if not cached, show a warning toast on failure, and cache results with a 60-minute expiration. Update usings for caching support.

closes #490