### PR TITLE
Add BalanceRefresher service for periodic balance updates

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/LoginPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/LoginPageViewModelTests.cs
@@ -33,6 +33,8 @@ public class LoginPageViewModelTests
     private readonly Mock<IDialogService> DialogService;
 
     private readonly Mock<IUpdateService> UpdateService;
+
+    private readonly Mock<IBalanceRefresher> BalanceRefresher;
     public LoginPageViewModelTests() {
         this.Mediator = new Mock<IMediator>();
         this.NavigationService = new Mock<INavigationService>();
@@ -43,11 +45,14 @@ public class LoginPageViewModelTests
         this.ApplicationUpdateLauncherService = new Mock<IApplicationUpdateLauncherService>();
         this.DialogService = new Mock<IDialogService>();
         this.UpdateService = new Mock<IUpdateService>();
+        this.BalanceRefresher = new Mock<IBalanceRefresher>();
+
 
         this.ViewModel = new LoginPageViewModel(this.Mediator.Object, this.NavigationService.Object, this.ApplicationCache.Object,
                                                 this.DeviceService.Object, this.ApplicationInfoService.Object,
                                                 this.DialogService.Object, this.NavigationParameterService.Object,
-                                                this.UpdateService.Object, this.ApplicationUpdateLauncherService.Object);
+                                                this.UpdateService.Object, this.ApplicationUpdateLauncherService.Object,
+                                                this.BalanceRefresher.Object);
         Logger.Initialise(new Logging.NullLogger());
     }
     
@@ -58,14 +63,12 @@ public class LoginPageViewModelTests
         this.Mediator.Setup(m => m.Send(It.IsAny<LoginRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.AccessToken));
         this.Mediator.Setup(m => m.Send(It.IsAny<LogonTransactionRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.PerformLogonResponseModel));
         this.Mediator.Setup(m => m.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
-        this.Mediator.Setup(m => m.Send(It.IsAny<GetMerchantBalanceRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantBalance));
-
+        
         this.ViewModel.LogonCommand.Execute(null);
         
         this.Mediator.Verify(x => x.Send(It.IsAny<LoginRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         this.Mediator.Verify(x => x.Send(It.IsAny<LogonTransactionRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         this.Mediator.Verify(x => x.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>()), Times.Once);
-        this.Mediator.Verify(x => x.Send(It.IsAny<GetMerchantBalanceRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         this.NavigationService.Verify(n => n.GoToHome(), Times.Once);
     }
 
@@ -79,7 +82,6 @@ public class LoginPageViewModelTests
         this.Mediator.Setup(m => m.Send(It.IsAny<LoginRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.AccessToken));
         this.Mediator.Setup(m => m.Send(It.IsAny<LogonTransactionRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.PerformLogonResponseModel));
         this.Mediator.Setup(m => m.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
-        this.Mediator.Setup(m => m.Send(It.IsAny<GetMerchantBalanceRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantBalance));
         this.ViewModel.ConfigHostUrl = configUrl;
 
         this.ViewModel.LogonCommand.Execute(null);
@@ -87,7 +89,6 @@ public class LoginPageViewModelTests
         this.Mediator.Verify(x => x.Send(It.IsAny<LoginRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         this.Mediator.Verify(x => x.Send(It.IsAny<LogonTransactionRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         this.Mediator.Verify(x => x.Send(It.IsAny<GetContractProductsRequest>(), It.IsAny<CancellationToken>()), Times.Once);
-        this.Mediator.Verify(x => x.Send(It.IsAny<GetMerchantBalanceRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         this.NavigationService.Verify(n => n.GoToHome(), Times.Once);
         if (String.IsNullOrEmpty(configUrl) == false){
             this.ApplicationCache.Verify(v => v.SetConfigHostUrl(It.IsAny<String>(), It.IsAny<MemoryCacheEntryOptions>()), Times.Once);

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/ApplicationCache.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/ApplicationCache.cs
@@ -46,6 +46,10 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
         MerchantDetailsModel GetMerchantDetails();
 
         void SetMerchantDetails(MerchantDetailsModel value, MemoryCacheEntryOptions options = default);
+
+        Decimal GetMerchantBalance();
+
+        void SetMerchantBalance(Decimal value, MemoryCacheEntryOptions options = default);
     }
 
     [ExcludeFromCodeCoverage]
@@ -163,6 +167,15 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
                                        MemoryCacheEntryOptions options = default)
         {
             this.Set("MerchantDetails", value, options);
+        }
+
+        public Decimal GetMerchantBalance() {
+            return this.TryGetValue<Decimal>("MerchantBalance");
+        }
+
+        public void SetMerchantBalance(Decimal value,
+                                       MemoryCacheEntryOptions options = default) {
+            this.Set("MerchantBalance", value, options);
         }
 
         public void SetUseTrainingMode(Boolean value,

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/BalanceRefresher.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/BalanceRefresher.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TransactionProcessor.Mobile.BusinessLogic.Logging;
+
+namespace TransactionProcessor.Mobile.BusinessLogic.Services
+{
+    public interface IBalanceRefresher
+    {
+        void StartRefreshing();
+        void StopRefreshing();
+    }
+
+    public class BalanceRefresher : IBalanceRefresher
+    {
+        private readonly IApplicationCache ApplicationCache;
+        private readonly IMerchantService MerchantService;
+        private CancellationTokenSource? _cts;
+
+        public BalanceRefresher(IApplicationCache applicationCache, IMerchantService merchantService) {
+            this.ApplicationCache = applicationCache;
+            this.MerchantService = merchantService;
+        }
+
+        public void StartRefreshing()
+        {
+            _cts = new CancellationTokenSource();
+            _ = RefreshLoopAsync(_cts.Token);
+        }
+
+        public void StopRefreshing()
+        {
+            _cts?.Cancel();
+        }
+
+        private async Task RefreshLoopAsync(CancellationToken token)
+        {
+            using PeriodicTimer timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
+
+            try
+            {
+                // Do the first refresh
+                await RefreshBalanceAsync();
+
+                while (await timer.WaitForNextTickAsync(token))
+                {
+                    await RefreshBalanceAsync();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        private async Task RefreshBalanceAsync()
+        {
+            decimal balance = await GetBalanceFromApi();
+
+            this.ApplicationCache.SetMerchantBalance(balance);
+        }
+
+        private async Task<decimal> GetBalanceFromApi()
+        {
+            var result = await this.MerchantService.GetMerchantBalance(CancellationToken.None);
+            if (result.IsSuccess)
+            {
+                return result.Data;
+            }
+
+            // Handle the failure case as needed, e.g., log the error or return a default value
+            Logger.LogWarning($"Failed to refresh merchant balance: {result.Message}");
+            return 0.0m;
+        }
+    }
+}

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
@@ -117,8 +117,7 @@ public class MerchantService : ClientProxyBase.ClientProxyBase, IMerchantService
             TokenResponseModel accessToken = this.ApplicationCache.GetAccessToken();
             Guid estateId = this.ApplicationCache.GetEstateId();
             Guid merchantId = this.ApplicationCache.GetMerchantId();
-
-
+            
             Logger.LogInformation("About to request merchant balance");
             Logger.LogDebug($"Merchant Balance Request details:  Estate Id {estateId} Merchant Id {merchantId} Access Token {accessToken.AccessToken}");
 

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
@@ -20,6 +20,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels
     {
         private readonly IApplicationInfoService ApplicationInfoService;
         private readonly IApplicationUpdateLauncherService ApplicationUpdateLauncherService;
+        private readonly IBalanceRefresher BalanceRefresher;
         private readonly IUpdateService UpdateService;
 
         private String userName;
@@ -37,10 +38,12 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels
                                   IDialogService dialogService,
                                   INavigationParameterService navigationParameterService,
                                   IUpdateService updateService,
-                                  IApplicationUpdateLauncherService applicationUpdateLauncherService) : base(applicationCache,dialogService,navigationService, deviceService, navigationParameterService)
+                                  IApplicationUpdateLauncherService applicationUpdateLauncherService,
+                                  IBalanceRefresher balanceRefresher) : base(applicationCache,dialogService,navigationService, deviceService, navigationParameterService)
         {
             this.ApplicationInfoService = applicationInfoService;
             this.ApplicationUpdateLauncherService = applicationUpdateLauncherService;
+            this.BalanceRefresher = balanceRefresher;
             this.Mediator = mediator;
             this.UpdateService = updateService;
         }
@@ -276,13 +279,15 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels
                 Result<List<ContractProductModel>> getMerchantContractProductsResult = await this.GetMerchantContractProducts();
                 this.HandleResult(getMerchantContractProductsResult);
 
-                await this.WriteTimingTrace(sw, "After GetMerchantContractProducts");
-                Result<Decimal> getMerchantBalanceResult =  await this.GetMerchantBalance();
-                this.HandleResult(getMerchantBalanceResult);
+                //await this.WriteTimingTrace(sw, "After GetMerchantContractProducts");
+                //Result<Decimal> getMerchantBalanceResult =  await this.GetMerchantBalance();
+                //this.HandleResult(getMerchantBalanceResult);
 
-                await this.WriteTimingTrace(sw, "After GetMerchantBalance");
+                //await this.WriteTimingTrace(sw, "After GetMerchantBalance");
                 this.ApplicationCache.SetIsLoggedIn(true);
-
+                
+                this.BalanceRefresher.StartRefreshing();
+                
                 await this.WriteTimingTrace(sw, "After SetIsLoggedIn");
                 await this.NavigationService.GoToHome();
             }

--- a/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
+++ b/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
@@ -89,7 +89,7 @@ namespace TransactionProcessor.Mobile.Extensions {
             builder.Services.AddSingleton<ITransactionService, TransactionService>();
             builder.Services.AddSingleton<IMerchantService, MerchantService>();
             builder.Services.AddSingleton<IUpdateService, UpdateService>();
-
+            builder.Services.AddSingleton<IBalanceRefresher,BalanceRefresher>();
             builder.RegisterConfigurationService().RegisterAuthenticationService().RegisterTransactionService().RegisterMerchantService();
             
             builder.Services.RegisterHttpClientX<ISecurityServiceClient, SecurityServiceClient>();


### PR DESCRIPTION
Introduce BalanceRefresher to periodically refresh the merchant's balance every 30 seconds and update the application cache. Extend IApplicationCache to support merchant balance storage and retrieval. Update LoginPageViewModel to use IBalanceRefresher and start refreshing after login. Register BalanceRefresher as a singleton in DI. Remove one-time balance fetch on login in favor of periodic updates. Minor logging improvements in MerchantService.

closes #515 