### PR TITLE
Improve user feedback for reconciliation and log upload

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Support/SupportPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Support/SupportPageViewModelTests.cs
@@ -2,6 +2,7 @@
 using MediatR;
 using Moq;
 using Shouldly;
+using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Database;
 using TransactionProcessor.Mobile.BusinessLogic.Requests;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
@@ -52,6 +53,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ViewModelTests.Support
         [Fact]
         public void SupportPageViewModel_UploadLogsCommand_Execute_IsExecuted()
         {
+            this.Mediator.Setup(m => m.Send(It.IsAny<SupportCommands.UploadLogsCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
             this.ViewModel.UploadLogsCommand.Execute(null);
 
             this.Mediator.Verify(m => m.Send(It.IsAny<SupportCommands.UploadLogsCommand>(),It.IsAny<CancellationToken>()),Times.Once);

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Transactions/Admin/AdminPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Transactions/Admin/AdminPageViewModelTests.cs
@@ -1,5 +1,7 @@
 ﻿using MediatR;
 using Moq;
+using SimpleResults;
+using TransactionProcessor.Mobile.BusinessLogic.Requests;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
 using TransactionProcessor.Mobile.BusinessLogic.ViewModels.Admin;
@@ -42,6 +44,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ViewModelTests.Transac
         [Fact]
         public void AdminPageViewModel_AdminCommand_Execute_IsExecuted()
         {
+            this.Mediator.Setup(m => m.Send(It.IsAny<TransactionCommands.PerformReconciliationCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
             this.ViewModel.ReconciliationCommand.Execute(null);
             this.NavigationService.Verify(n => n.GoToHome(), Times.Once);
         }

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Admin/AdminPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Admin/AdminPageViewModel.cs
@@ -41,10 +41,15 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.Admin
             CorrelationIdProvider.NewId();
             TransactionCommands.PerformReconciliationCommand command = new TransactionCommands.PerformReconciliationCommand(DateTime.Now, String.Empty, this.ApplicationInfoService.VersionString);
 
-            await this.Mediator.Send(command);
+            Result<PerformReconciliationResponseModel> result = await this.Mediator.Send(command);
 
-            // TODO: Act on the response (display message or something)...
-            await this.NavigationService.GoToHome();
+            if (result.IsSuccess) {
+                await this.DialogService.ShowInformationToast("Reconciliation Succeeded");
+                await this.NavigationService.GoToHome();
+            }
+            else {
+                await this.DialogService.ShowWarningToast("Reconciliation Failed");
+            }
         }
         
         #endregion

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Support/SupportPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Support/SupportPageViewModel.cs
@@ -71,17 +71,20 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.Support
 
             SupportCommands.UploadLogsCommand command = new(String.Empty);
 
-            await this.Mediator.Send(command, CancellationToken.None);
+            var result = await this.Mediator.Send(command, CancellationToken.None);
 
-            // TODO: Act on the response (display message or something)...
-            //await this.NavigationService.GoBack();
+            if (result.IsSuccess) {
+                await this.DialogService.ShowInformationToast("Logs have been uploaded successfully.");
+                await this.NavigationService.GoBack();
+            } else {
+                await this.DialogService.ShowWarningToast("Failed to upload logs.");
+            }
         }
 
         [RelayCommand]
         private async Task ViewLogs() {
             Logger.LogInformation("ViewLogs called");
 
-            // TODO: Act on the response (display message or something)...
             await this.NavigationService.GoToViewLogsPage();
         }
 


### PR DESCRIPTION
Added success and failure toast notifications for reconciliation and log upload actions in AdminPageViewModel and SupportPageViewModel. Navigation now occurs only on success, replacing previous TODOs and enhancing user experience with clear operation outcomes.

closes #489 
closes #497 