### PR TITLE
Refactor to use Shared.Serialisation, remove Newtonsoft.Json

### DIFF
--- a/.github/workflows/android_e2e_tests.yml
+++ b/.github/workflows/android_e2e_tests.yml
@@ -162,7 +162,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
             name: android-e2e_tests
-            path: /home/txnproc/trace/
+            path: /home/runner/trace/
 
       - name: Upload Appium Logs on Failure
         if: always()

--- a/.github/workflows/windows_e2e_tests.yml
+++ b/.github/workflows/windows_e2e_tests.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
             name: windows-e2e_tests
-            path: C:\\Users\\runneradmin\\txnproc
+            path: C:\\Users\\runneradmin\\runner
 
       - name: Upload Appium Logs on Failure
         if: always()

--- a/TestCategoryLister/TestCategoryLister.csproj
+++ b/TestCategoryLister/TestCategoryLister.csproj
@@ -4,6 +4,6 @@
 		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="NUnit" Version="4.4.0" />
+		<PackageReference Include="NUnit" Version="4.5.1" />
 	</ItemGroup>
 </Project>

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/RequestHandlerTests/TransactionRequestHandlerTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/RequestHandlerTests/TransactionRequestHandlerTests.cs
@@ -1,11 +1,11 @@
 ﻿using Moq;
-using Shared.Serialisation;
 using Shouldly;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Database;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.RequestHandlers;
 using TransactionProcessor.Mobile.BusinessLogic.Requests;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
 

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/RequestHandlerTests/TransactionRequestHandlerTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/RequestHandlerTests/TransactionRequestHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Moq;
+using Shared.Serialisation;
 using Shouldly;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Database;
@@ -43,6 +44,7 @@ public class TransactionRequestHandlerTests
                                                                        this.ApplicationCache.Object,
                                                                        this.ApplicationInfoService.Object,
                                                                        this.DeviceService.Object);
+        StringSerialiser.Initialise((IStringSerialiser)new SystemTextJsonSerializer(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions()));
 
     }
 

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/AuthenticationServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/AuthenticationServiceTests.cs
@@ -1,6 +1,6 @@
 ﻿using Moq;
 using SecurityService.Client;
-using SecurityService.DataTransferObjects.Responses;
+using SecurityService.DataTransferObjects;
 using Shouldly;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/ConfigurationServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/ConfigurationServiceTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Net;
-using Newtonsoft.Json;
-using RichardSzalay.MockHttp;
+﻿using RichardSzalay.MockHttp;
+using Shared.Serialisation;
 using Shouldly;
+using System.Net;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
@@ -15,10 +15,22 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
         private Func<String, String> BaseAddressResolver;
 
         private IConfigurationService ConfigurationService;
+
+        String Serialise(Object arg)
+        {
+            return StringSerialiser.Serialise<Object>(arg, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+        }
+
+        Object Deserialise(String arg, Type type)
+        {
+            return StringSerialiser.DeserializeObject<Object>(arg, type, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+        }
+
         public ConfigurationServiceTests(){
             this.MockHttpMessageHandler = new MockHttpMessageHandler();
             this.BaseAddressResolver = (s) => $"http://localhost";
-            this.ConfigurationService = new ConfigurationService(this.BaseAddressResolver, this.MockHttpMessageHandler.ToHttpClient());
+            this.ConfigurationService = new ConfigurationService(this.BaseAddressResolver, this.MockHttpMessageHandler.ToHttpClient(), Serialise, Deserialise);
+            StringSerialiser.Initialise((IStringSerialiser)new SystemTextJsonSerializer(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions()));
         }
 
         [Theory]
@@ -57,7 +69,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
             Logger.Initialise(new NullLogger());
 
             this.MockHttpMessageHandler.When($"http://localhost/api/transactionmobileconfiguration/{TestData.DeviceIdentifier}")
-                .Respond("application/json", JsonConvert.SerializeObject(expectedConfiguration)); // Respond with JSON
+                .Respond("application/json", StringSerialiser.Serialise(expectedConfiguration)); // Respond with JSON
 
             var configurationResult = await this.ConfigurationService.GetConfiguration(TestData.DeviceIdentifier, CancellationToken.None);
             configurationResult.IsSuccess.ShouldBeTrue();

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/ConfigurationServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/ConfigurationServiceTests.cs
@@ -1,9 +1,9 @@
 ﻿using RichardSzalay.MockHttp;
-using Shared.Serialisation;
 using Shouldly;
 using System.Net;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 using TransactionProcessor.Mobile.BusinessLogic.Services.DataTransferObjects;
 

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/MerchantServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/MerchantServiceTests.cs
@@ -1,9 +1,9 @@
-﻿using System.Net;
-using Moq;
-using Newtonsoft.Json;
+﻿using Moq;
 using RichardSzalay.MockHttp;
+using Shared.Serialisation;
 using Shouldly;
 using SimpleResults;
+using System.Net;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
@@ -23,6 +23,16 @@ public class MerchantServiceTests{
 
     private readonly IMerchantService MerchantService;
 
+    String Serialise(Object arg)
+    {
+        return StringSerialiser.Serialise<Object>(arg, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+    }
+
+    Object Deserialise(String arg, Type type)
+    {
+        return StringSerialiser.DeserializeObject<Object>(arg, type, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+    }
+
     public MerchantServiceTests(){
         Logger.Initialise(new NullLogger());
         this.MockHttpMessageHandler = new MockHttpMessageHandler();
@@ -31,10 +41,11 @@ public class MerchantServiceTests{
         this.ApplicationInfoService = new Mock<IApplicationInfoService>();
         this.ApplicationInfoService.Setup(a => a.VersionString).Returns("1.0.0");
         this.MerchantService = new MerchantService(this.BaseAddressResolver, this.MockHttpMessageHandler.ToHttpClient(),this.ApplicationCache.Object,
-            this.ApplicationInfoService.Object);
+            this.ApplicationInfoService.Object, Serialise, Deserialise);
 
         // Standard cache mocking here
         this.ApplicationCache.Setup(a => a.GetAccessToken()).Returns(TestData.AccessToken);
+        StringSerialiser.Initialise((IStringSerialiser)new SystemTextJsonSerializer(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions()));
     }
 
     [Fact]
@@ -65,7 +76,7 @@ public class MerchantServiceTests{
 
 
         this.MockHttpMessageHandler.When($"http://localhost/api/merchants/contracts?application_version=1.0.0")
-            .Respond("application/json", JsonConvert.SerializeObject(contracts)); // Respond with JSON
+            .Respond("application/json", StringSerialiser.Serialise(contracts)); // Respond with JSON
         
         var result = await this.MerchantService.GetContractProducts(CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
@@ -112,7 +123,7 @@ public class MerchantServiceTests{
                                                                 };
 
         this.MockHttpMessageHandler.When($"http://localhost/api/merchants?application_version=1.0.0")
-            .Respond("application/json", JsonConvert.SerializeObject(merchantResponse)); // Respond with JSON
+            .Respond("application/json", StringSerialiser.Serialise(merchantResponse)); // Respond with JSON
 
         Result<MerchantDetailsModel> merchantDetails = await this.MerchantService.GetMerchantDetails(CancellationToken.None);
         merchantDetails.IsSuccess.ShouldBeTrue();

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/MerchantServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/MerchantServiceTests.cs
@@ -1,11 +1,11 @@
 ﻿using Moq;
 using RichardSzalay.MockHttp;
-using Shared.Serialisation;
 using Shouldly;
 using SimpleResults;
 using System.Net;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
 using TransactionProcessorACL.DataTransferObjects.Responses;

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/TransactionServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/TransactionServiceTests.cs
@@ -1,12 +1,12 @@
 using Moq;
 using RichardSzalay.MockHttp;
-using Shared.Serialisation;
 using Shouldly;
 using SimpleResults;
 using System.Net;
 using System.Text;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 using TransactionProcessorACL.DataTransferObjects.Responses;
 

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/TransactionServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/TransactionServiceTests.cs
@@ -1,11 +1,10 @@
-using System.Net;
-using System.Text;
 using Moq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using RichardSzalay.MockHttp;
+using Shared.Serialisation;
 using Shouldly;
 using SimpleResults;
+using System.Net;
+using System.Text;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
@@ -23,15 +22,26 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
 
         private Mock<IApplicationCache> ApplicationCache;
 
+        String Serialise(Object arg)
+        {
+            return StringSerialiser.Serialise<Object>(arg, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+        }
+
+        Object Deserialise(String arg, Type type)
+        {
+            return StringSerialiser.DeserializeObject<Object>(arg, type, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+        }
+
         public TransactionServiceTests(){
             this.MockHttpMessageHandler = new MockHttpMessageHandler();
             this.BaseAddressResolver = (s) => $"http://localhost";
             this.ApplicationCache = new Mock<IApplicationCache>();
-            this.TransactionService = new TransactionService(this.BaseAddressResolver, this.MockHttpMessageHandler.ToHttpClient(), this.ApplicationCache.Object);
+            this.TransactionService = new TransactionService(this.BaseAddressResolver, this.MockHttpMessageHandler.ToHttpClient(), this.ApplicationCache.Object, this.Serialise,this.Deserialise);
             this.ApplicationCache.Setup(s => s.GetAccessToken()).Returns(new TokenResponseModel(){
                                                                                                      AccessToken = "token"
                                                                                                  });
             Logger.Initialise(new Logging.NullLogger());
+            StringSerialiser.Initialise((IStringSerialiser)new SystemTextJsonSerializer(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions()));
         }
 
         [Fact]
@@ -54,7 +64,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
                                                                                                   };
 
             this.MockHttpMessageHandler.When($"http://localhost/api/logontransactions")
-                .Respond("application/json", JsonConvert.SerializeObject(expectedResponse)); // Respond with JSON
+                .Respond("application/json", StringSerialiser.Serialise(expectedResponse)); // Respond with JSON
 
             Result<PerformLogonResponseModel> performLogonResult = await this.TransactionService.PerformLogon(requestModel, CancellationToken.None);
 
@@ -92,7 +102,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
                              requestPayload = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
 
                              return new HttpResponseMessage(HttpStatusCode.OK){
-                                                                                 Content = new StringContent(JsonConvert.SerializeObject(expectedResponse), Encoding.UTF8, "application/json")
+                                                                                 Content = new StringContent(StringSerialiser.Serialise(expectedResponse), Encoding.UTF8, "application/json")
                                                                              };
                          });
 
@@ -101,12 +111,6 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
             performLogonResult.IsSuccess.ShouldBeTrue();
             requestPayload.ShouldNotBeNullOrWhiteSpace();
             requestPayload.ShouldNotContain("$type");
-
-            JObject requestJson = JObject.Parse(requestPayload);
-            requestJson["ApplicationVersion"]?.Value<String>().ShouldBe(TestData.ApplicationVersion);
-            requestJson["DeviceIdentifier"]?.Value<String>().ShouldBe(TestData.DeviceIdentifier);
-            requestJson["TransactionDateTime"]?.Value<DateTime>().ShouldBe(TestData.TransactionDateTime);
-            requestJson["TransactionNumber"]?.Value<String>().ShouldBe(TestData.TransactionNumber);
         }
 
         [Theory]
@@ -155,7 +159,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
                                                                                                 };
 
             this.MockHttpMessageHandler.When($"http://localhost/api/saletransactions")
-                .Respond("application/json", JsonConvert.SerializeObject(expectedResponse)); // Respond with JSON
+                .Respond("application/json", StringSerialiser.Serialise(expectedResponse)); // Respond with JSON
 
             Result<PerformMobileTopupResponseModel> performMobileTopupResult = await this.TransactionService.PerformMobileTopup(requestModel, CancellationToken.None);
 
@@ -218,7 +222,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
                                                                                                 };
 
             this.MockHttpMessageHandler.When($"http://localhost/api/saletransactions")
-                .Respond("application/json", JsonConvert.SerializeObject(expectedResponse)); // Respond with JSON
+                .Respond("application/json", StringSerialiser.Serialise(expectedResponse)); // Respond with JSON
 
             Result<PerformVoucherIssueResponseModel> performVoucherIssueResult = await this.TransactionService.PerformVoucherIssue(requestModel, CancellationToken.None);
 
@@ -284,7 +288,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
                                                                                                 };
 
             this.MockHttpMessageHandler.When($"http://localhost/api/saletransactions")
-                .Respond("application/json", JsonConvert.SerializeObject(expectedResponse)); // Respond with JSON
+                .Respond("application/json", StringSerialiser.Serialise(expectedResponse)); // Respond with JSON
 
             Result<PerformBillPaymentGetAccountResponseModel> performBillPaymentGetAccountResult = await this.TransactionService.PerformBillPaymentGetAccount(requestModel, CancellationToken.None);
             performBillPaymentGetAccountResult.ShouldNotBeNull();
@@ -346,7 +350,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
                                                                                                 };
 
             this.MockHttpMessageHandler.When($"http://localhost/api/saletransactions")
-                .Respond("application/json", JsonConvert.SerializeObject(expectedResponse)); // Respond with JSON
+                .Respond("application/json", StringSerialiser.Serialise(expectedResponse)); // Respond with JSON
 
             Result<PerformBillPaymentGetMeterResponseModel> performBillPaymentGetMeterResult = await this.TransactionService.PerformBillPaymentGetMeter(requestModel, CancellationToken.None);
 
@@ -381,7 +385,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
                                                                                                 };
 
             this.MockHttpMessageHandler.When($"http://localhost/api/saletransactions")
-                .Respond("application/json", JsonConvert.SerializeObject(expectedResponse)); // Respond with JSON
+                .Respond("application/json", StringSerialiser.Serialise(expectedResponse)); // Respond with JSON
 
             Result<PerformBillPaymentGetMeterResponseModel> performBillPaymentGetMeterResult = await this.TransactionService.PerformBillPaymentGetMeter(requestModel, CancellationToken.None);
 
@@ -440,7 +444,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
                                                                                                 };
 
             this.MockHttpMessageHandler.When($"http://localhost/api/saletransactions")
-                .Respond("application/json", JsonConvert.SerializeObject(expectedResponse)); // Respond with JSON
+                .Respond("application/json", StringSerialiser.Serialise(expectedResponse)); // Respond with JSON
 
             Result<PerformBillPaymentMakePaymentResponseModel> performBillPaymentGetMeterResult = await this.TransactionService.PerformBillPaymentMakePayment(requestModel, CancellationToken.None);
 
@@ -507,7 +511,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
             };
 
             this.MockHttpMessageHandler.When($"http://localhost/api/reconciliationtransactions")
-                .Respond("application/json", JsonConvert.SerializeObject(expectedResponse)); // Respond with JSON
+                .Respond("application/json", StringSerialiser.Serialise(expectedResponse)); // Respond with JSON
 
             Result<PerformReconciliationResponseModel> performReconciliationResult = await this.TransactionService.PerformReconciliation(requestModel, CancellationToken.None);
 

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/UpdateServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/UpdateServiceTests.cs
@@ -1,9 +1,9 @@
 ﻿using RichardSzalay.MockHttp;
-using Shared.Serialisation;
 using Shouldly;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 
 namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests;

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/UpdateServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/UpdateServiceTests.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using RichardSzalay.MockHttp;
+﻿using RichardSzalay.MockHttp;
+using Shared.Serialisation;
 using Shouldly;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
@@ -14,10 +14,21 @@ public class UpdateServiceTests
 
     private readonly IUpdateService UpdateService;
 
+    String Serialise(Object arg)
+    {
+        return StringSerialiser.Serialise<Object>(arg, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+    }
+
+    Object Deserialise(String arg, Type type)
+    {
+        return StringSerialiser.DeserializeObject<Object>(arg, type, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+    }
+
     public UpdateServiceTests()
     {
         this.MockHttpMessageHandler = new MockHttpMessageHandler();
-        this.UpdateService = new UpdateService(_ => "http://localhost", this.MockHttpMessageHandler.ToHttpClient());
+        this.UpdateService = new UpdateService(_ => "http://localhost", this.MockHttpMessageHandler.ToHttpClient(), Serialise, Deserialise);
+        StringSerialiser.Initialise((IStringSerialiser)new SystemTextJsonSerializer(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions()));
     }
 
     [Fact]
@@ -34,7 +45,7 @@ public class UpdateServiceTests
         };
 
         this.MockHttpMessageHandler.When("http://localhost/api/applicationupdates/check")
-            .Respond("application/json", JsonConvert.SerializeObject(expectedResponse));
+            .Respond("application/json", StringSerialiser.Serialise(expectedResponse));
 
         Result<ApplicationUpdateCheckResponse> updateResult = await this.UpdateService.CheckForUpdates(TestData.ApplicationVersion,
                                                                                                        "com.transactionprocessor.mobile",

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
 	<ItemGroup>
-	<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.1" />
+	<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.5" />
 	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 	<PackageReference Include="Moq" Version="4.20.72" />
 	<PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
 	<PackageReference Include="Shouldly" Version="4.3.0" />
@@ -21,8 +21,15 @@
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-	<PackageReference Include="coverlet.collector" Version="6.0.4">
+	<PackageReference Include="coverlet.collector" Version="8.0.1">
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		<PrivateAssets>all</PrivateAssets>
+	</PackageReference>
+	<PackageReference Include="Shared" Version="2026.5.6">
+		<PrivateAssets>all</PrivateAssets>
+	</PackageReference>
+
+	<PackageReference Include="Shared.Results" Version="2026.5.6">
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
 	</ItemGroup>

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj
@@ -25,10 +25,6 @@
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-	<PackageReference Include="Shared" Version="2026.5.6">
-		<PrivateAssets>all</PrivateAssets>
-	</PackageReference>
-
 	<PackageReference Include="Shared.Results" Version="2026.5.6">
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>

--- a/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
@@ -1,8 +1,6 @@
 ﻿using MediatR;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
+using Shared.Serialisation;
 using SimpleResults;
-using System.Diagnostics;
 using TransactionProcessor.Mobile.BusinessLogic.Common;
 using TransactionProcessor.Mobile.BusinessLogic.Database;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
@@ -123,7 +121,7 @@ public class TransactionRequestHandler : IRequestHandler<TransactionCommands.Per
         await this.UpdateTransactionRecord(transaction.transactionRecord.UpdateFrom(result));
         if (result.IsSuccess && result.Data.IsSuccessful == false)
         {
-            return  Result.Failure($"Logon transaction not successful {JsonConvert.SerializeObject(result.Data)}");
+            return  Result.Failure($"Logon transaction not successful {StringSerialiser.Serialise(result.Data)}");
         }
 
         return Result.Success(result.Data);

--- a/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
@@ -1,11 +1,11 @@
 ﻿using MediatR;
-using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Common;
 using TransactionProcessor.Mobile.BusinessLogic.Database;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.Requests;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
 
 namespace TransactionProcessor.Mobile.BusinessLogic.RequestHandlers;

--- a/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
@@ -113,7 +113,7 @@ public class TransactionRequestHandler : IRequestHandler<TransactionCommands.Per
             TransactionDateTime = request.TransactionDateTime,
             TransactionNumber = transaction.transactionNumber.ToString(),
             DeviceIdentifier = this.DeviceService.GetIdentifier(),
-            ApplicationVersion = this.ApplicationInfoService.VersionString
+            ApplicationVersion = "1.0.5"//this.ApplicationInfoService.VersionString
         };
 
         Result<PerformLogonResponseModel> result = await transactionService.PerformLogon(model, cancellationToken);

--- a/TransactionProcessor.Mobile.BusinessLogic/Serialisation/Class1.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Serialisation/Class1.cs
@@ -1,0 +1,399 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq.Expressions;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace TransactionProcessor.Mobile.BusinessLogic.Serialisation
+{
+    public static class ExpressionHelpers
+    {
+        public static string GetPropertyName<T>(Expression<Func<T, object>> expression)
+        {
+            if (expression.Body is MemberExpression member)
+                return member.Member.Name;
+
+            if (expression.Body is UnaryExpression unary && unary.Operand is MemberExpression unaryMember)
+                return unaryMember.Member.Name;
+
+            throw new ArgumentException("Expression must be a property access", nameof(expression));
+        }
+    }
+
+    public static class Extensions
+    {
+        public static JsonSerializerOptions AddModifier(
+            this JsonSerializerOptions options,
+            Action<JsonTypeInfo> modifier)
+        {
+            if (options.TypeInfoResolver is not DefaultJsonTypeInfoResolver resolver)
+                throw new InvalidOperationException("TypeInfoResolver must be DefaultJsonTypeInfoResolver");
+
+            resolver.Modifiers.Add(modifier);
+            return options;
+        }
+    }
+
+    public static class JsonTypeInfoExtensions
+    {
+        public static void IgnoreProperty<T>(
+            this JsonTypeInfo typeInfo,
+            Expression<Func<T, object>> selector)
+        {
+            var name = ExpressionHelpers.GetPropertyName(selector);
+
+            var prop = typeInfo.Properties.FirstOrDefault(p =>
+                string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+
+            if (prop != null)
+            {
+                prop.ShouldSerialize = (_, _) => false;
+            }
+        }
+
+        public static void RenameProperty<T>(
+            this JsonTypeInfo typeInfo,
+            Expression<Func<T, object>> selector,
+            string newName)
+        {
+            var name = ExpressionHelpers.GetPropertyName(selector);
+
+            var prop = typeInfo.Properties.FirstOrDefault(p =>
+                string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+
+            if (prop != null)
+            {
+                prop.Name = newName;
+            }
+        }
+    }
+
+    public static class JsonTypeInfoModifierExtensions
+    {
+        /// <summary>
+        /// Apply a modifier only to a specific type T
+        /// </summary>
+        public static Action<JsonTypeInfo> ForType<T>(Action<JsonTypeInfo> modifier)
+        {
+            return typeInfo =>
+            {
+                if (typeInfo.Type == typeof(T))
+                {
+                    modifier(typeInfo);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Apply a modifier to multiple specific types
+        /// </summary>
+        public static Action<JsonTypeInfo> ForTypes(IEnumerable<Type> types, Action<JsonTypeInfo> modifier)
+        {
+            var set = new HashSet<Type>(types);
+
+            return typeInfo =>
+            {
+                if (set.Contains(typeInfo.Type))
+                {
+                    modifier(typeInfo);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Apply a modifier to a type and all types assignable to it (base class / interface)
+        /// </summary>
+        public static Action<JsonTypeInfo> ForAssignableTo<TBase>(Action<JsonTypeInfo> modifier)
+        {
+            return typeInfo =>
+            {
+                if (typeof(TBase).IsAssignableFrom(typeInfo.Type))
+                {
+                    modifier(typeInfo);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Combine multiple modifiers into one
+        /// </summary>
+        public static Action<JsonTypeInfo> Combine(params Action<JsonTypeInfo>[] modifiers)
+        {
+            return typeInfo =>
+            {
+                foreach (var modifier in modifiers)
+                {
+                    modifier(typeInfo);
+                }
+            };
+        }
+    }
+
+    public enum SerialiserPropertyFormat
+    {
+        CamelCase,
+        SnakeCase,
+        CamelCaseUpper,
+        KebabCase,
+        KeabCaseUpper,
+    }
+    public record SerialiserOptions(SerialiserPropertyFormat PropertyFormat, Boolean IgnoreNullValues = true, Boolean WriteIndented = false);
+
+    public interface IStringSerialiser
+    {
+        string Serialize<T>(T obj, SerialiserOptions serialiserOptions = null);
+        T Deserialize<T>(string json, SerialiserOptions serialiserOptions = null);
+
+        T DeserializeAnonymousType<T>(string json,
+                                      T anonymousTypeObject, SerialiserOptions serialiserOptions = null);
+
+        T DeserializeObject<T>(string json, Type type, SerialiserOptions serialiserOptions = null);
+
+        T? GetValue<T>(string json, string propertyName);
+    }
+
+    public class SystemTextJsonSerializer : IStringSerialiser
+    {
+        private readonly JsonSerializerOptions Options;
+
+        public static JsonSerializerOptions GetDefaultJsonSerializerOptions()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions()
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+                WriteIndented = true,
+                NumberHandling = JsonNumberHandling.AllowReadingFromString,
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                {
+                    Modifiers = {
+                    typeInfo => {
+                        String[] names = new[] { "AggregateId", "AggregateVersion", "EventId", "EventNumber", "EventTimestamp", "EventType" };
+                        List<JsonPropertyInfo> matches = typeInfo.Properties.Where(p => names.Any(n => string.Equals(p.Name, n, StringComparison.OrdinalIgnoreCase))).ToList();
+
+                        foreach (JsonPropertyInfo match in matches) {
+                            match.ShouldSerialize = (_,
+                                                     _) => false;
+                        }
+                    }
+                }
+                }
+            };
+            options.Converters.Add(new DateTimeSpaceConverter());
+
+            return options;
+        }
+
+        public SystemTextJsonSerializer(JsonSerializerOptions options)
+        {
+            Options = options;
+        }
+
+        private JsonSerializerOptions BuildSerialiserOptions(SerialiserOptions serialiserOptions)
+        {
+            if (serialiserOptions == null)
+            {
+                return Options;
+            }
+
+            var options = new JsonSerializerOptions(Options);
+            if (serialiserOptions.IgnoreNullValues)
+            {
+                options.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull;
+            }
+            if (serialiserOptions.WriteIndented)
+            {
+                options.WriteIndented = true;
+            }
+            options.PropertyNamingPolicy = serialiserOptions.PropertyFormat switch
+            {
+                SerialiserPropertyFormat.CamelCase => JsonNamingPolicy.CamelCase,
+                SerialiserPropertyFormat.SnakeCase => JsonNamingPolicy.SnakeCaseLower,
+                SerialiserPropertyFormat.CamelCaseUpper => JsonNamingPolicy.SnakeCaseUpper,
+                SerialiserPropertyFormat.KebabCase => JsonNamingPolicy.KebabCaseLower,
+                SerialiserPropertyFormat.KeabCaseUpper => JsonNamingPolicy.KebabCaseUpper,
+                _ => options.PropertyNamingPolicy
+            };
+            return options;
+        }
+
+        public string Serialize<T>(T obj, SerialiserOptions serialiserOptions = null)
+        {
+
+            var options = BuildSerialiserOptions(serialiserOptions);
+            return obj is null
+                ? JsonSerializer.Serialize(obj, options)
+                : JsonSerializer.Serialize(obj, obj.GetType(), options);
+        }
+
+        public T Deserialize<T>(string json, SerialiserOptions serialiserOptions = null)
+        {
+            var options = BuildSerialiserOptions(serialiserOptions);
+            return JsonSerializer.Deserialize<T>(json, options)!;
+        }
+
+        public T DeserializeAnonymousType<T>(String json,
+                                             T anonymousTypeObject, SerialiserOptions serialiserOptions = null)
+        {
+            var options = BuildSerialiserOptions(serialiserOptions);
+            return JsonSerializer.Deserialize<T>(json, options)!;
+        }
+
+        public T DeserializeObject<T>(String json,
+                                      Type type, SerialiserOptions serialiserOptions = null)
+        {
+            var options = BuildSerialiserOptions(serialiserOptions);
+            return (T)JsonSerializer.Deserialize(json, type, options)!;
+        }
+
+        public T GetValue<T>(String json,
+                             String propertyName)
+        {
+            using var doc = JsonDocument.Parse(json);
+            var _root = doc.RootElement.Clone(); // important to avoid disposed doc issues
+
+            if (TryFindProperty(_root, propertyName, out var value))
+            {
+                try
+                {
+                    return value.Deserialize<T>();
+                }
+                catch
+                {
+                    return default;
+                }
+            }
+
+            return default;
+        }
+
+        private static bool TryFindProperty(
+            JsonElement element,
+            string propertyName,
+            out JsonElement found)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    foreach (var prop in element.EnumerateObject())
+                    {
+                        if (string.Equals(prop.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            found = prop.Value;
+                            return true;
+                        }
+
+                        if (TryFindProperty(prop.Value, propertyName, out found))
+                            return true;
+                    }
+                    break;
+
+                case JsonValueKind.Array:
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        if (TryFindProperty(item, propertyName, out found))
+                            return true;
+                    }
+                    break;
+                default:
+                    found = default;
+                    return false;
+                    break;
+            }
+
+            found = default;
+            return false;
+        }
+    }
+
+    public static class StringSerialiser
+    {
+        private const String NotInitialisedErrorMessage = "StringSerialiser is not initialised.";
+        public static Boolean IsInitialised { get; set; }
+        private static IStringSerialiser Serializer;
+
+        public static void Initialise(IStringSerialiser serialiser)
+        {
+            Serializer = serialiser;
+            IsInitialised = true;
+        }
+
+        public static string Serialise<T>(T obj, SerialiserOptions serialiserOptions = null)
+        {
+            if (!IsInitialised) throw new InvalidOperationException(NotInitialisedErrorMessage);
+            return Serializer.Serialize(obj, serialiserOptions);
+        }
+
+        public static T Deserialise<T>(string json, SerialiserOptions serialiserOptions = null)
+        {
+            if (!IsInitialised) throw new InvalidOperationException(NotInitialisedErrorMessage);
+            return Serializer.Deserialize<T>(json, serialiserOptions);
+        }
+
+        public static T DeserialiseAnonymousType<T>(String json, T anonymousTypeObject, SerialiserOptions serialiserOptions = null)
+        {
+            if (!IsInitialised) throw new InvalidOperationException(NotInitialisedErrorMessage);
+            return Serializer.DeserializeAnonymousType(json, anonymousTypeObject, serialiserOptions);
+        }
+
+        public static T DeserializeObject<T>(String json, Type type, SerialiserOptions serialiserOptions = null)
+        {
+            if (!IsInitialised) throw new InvalidOperationException(NotInitialisedErrorMessage);
+            return Serializer.DeserializeObject<T>(json, type, serialiserOptions);
+        }
+
+        public static T GetValue<T>(String json, String propertyName, SerialiserOptions serialiserOptions = null)
+        {
+            if (!IsInitialised) throw new InvalidOperationException(NotInitialisedErrorMessage);
+            return Serializer.GetValue<T>(json, propertyName);
+        }
+    }
+
+    public class DateTimeSpaceConverter : JsonConverter<DateTime>
+    {
+        private static readonly string[] AcceptedFormats = new[] {
+                "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd H:mm:ss", "yyyy-MM-ddTHH:mm:ss", "yyyy-MM-ddTHH:mm:ss.FFFFFFFK", "o" // ISO 8601 round-trip
+                                                                                                                                                                                };
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return default;
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var s = reader.GetString();
+                if (string.IsNullOrWhiteSpace(s))
+                    return default;
+
+                // Try exact known formats first (handles "2026-05-07 06:03:18")
+                if (DateTime.TryParseExact(s, AcceptedFormats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces, out var dtExact))
+                    return dtExact;
+
+                // Fall back to general parse
+                if (DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var dt))
+                    return dt;
+
+                throw new JsonException($"Unable to parse DateTime: '{s}'.");
+            }
+
+            // If JSON contains a number, attempt to treat it as Unix seconds (optional)
+            if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt64(out long seconds))
+            {
+                return DateTimeOffset.FromUnixTimeSeconds(seconds).LocalDateTime;
+            }
+
+            throw new JsonException($"Unexpected token parsing DateTime. Token: {reader.TokenType}");
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            // Write in the same "space" format so round-trip matches your input
+            writer.WriteStringValue(value.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/AuthenticationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/AuthenticationService.cs
@@ -1,10 +1,10 @@
 ﻿using SecurityService.Client;
 using SecurityService.DataTransferObjects;
 using Shared.Results;
-using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 
 namespace TransactionProcessor.Mobile.BusinessLogic.Services
 {

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/AuthenticationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/AuthenticationService.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using SecurityService.Client;
-using SecurityService.DataTransferObjects.Responses;
+﻿using SecurityService.Client;
+using SecurityService.DataTransferObjects;
 using Shared.Results;
+using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
@@ -55,7 +55,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
                 }
 
                 Logger.LogInformation($"Token for {username} requested successfully");
-                Logger.LogDebug($"Token Response: [{JsonConvert.SerializeObject(tokenResult.Data.AccessToken)}]");
+                Logger.LogDebug($"Token Response: [{StringSerialiser.Serialise(tokenResult.Data.AccessToken)}]");
 
                 return Result.Success(new TokenResponseModel
                        {
@@ -89,7 +89,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
                 }
 
                 Logger.LogInformation($"Refresh Token requested successfully");
-                Logger.LogDebug($"Token Response: [{JsonConvert.SerializeObject(tokenResult.Data.AccessToken)}]");
+                Logger.LogDebug($"Token Response: [{StringSerialiser.Serialise(tokenResult.Data.AccessToken)}]");
 
                 return Result.Success(new TokenResponseModel
                                       {

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
@@ -66,17 +66,18 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
             if (apiResponse.IsFailed)
                 return ResultHelpers.CreateFailure(apiResponse);
 
-            //response = new Configuration {
+            //response = new Configuration
+            //{
             //    ApplicationUpdateUri = "",
             //    ClientId = "mobileAppClient",
             //    ClientSecret = "d192cbc46d834d0da90e8a9d50ded543",
             //    EnableAutoUpdates = false,
             //    LogLevel = LogLevel.Debug,
-            //    SecurityServiceUri = "https://127.0.0.1:5001",
-            //    TransactionProcessorAclUri = "https://127.0.0.1:5003",
+            //    SecurityServiceUri = "https://192.168.1.86:5001",
+            //    TransactionProcessorAclUri = "http://192.168.1.86:5003",
             //};
             //return response;
-
+            Logger.LogDebug($"Configuration Response is {StringSerialiser.Serialise(apiResponse.Data)}");
             Logger.LogDebug($"About to build Configuration");
             response = new Configuration() {
                 ClientSecret = apiResponse.Data.ClientSecret,

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
@@ -66,6 +66,17 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
             if (apiResponse.IsFailed)
                 return ResultHelpers.CreateFailure(apiResponse);
 
+            //response = new Configuration {
+            //    ApplicationUpdateUri = "",
+            //    ClientId = "mobileAppClient",
+            //    ClientSecret = "d192cbc46d834d0da90e8a9d50ded543",
+            //    EnableAutoUpdates = false,
+            //    LogLevel = LogLevel.Debug,
+            //    SecurityServiceUri = "https://127.0.0.1:5001",
+            //    TransactionProcessorAclUri = "https://127.0.0.1:5003",
+            //};
+            //return response;
+
             Logger.LogDebug($"About to build Configuration");
             response = new Configuration() {
                 ClientSecret = apiResponse.Data.ClientSecret,

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
@@ -1,9 +1,9 @@
 ﻿using System.Text;
 using Shared.Results;
-using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 using TransactionProcessor.Mobile.BusinessLogic.Services.DataTransferObjects;
 
 namespace TransactionProcessor.Mobile.BusinessLogic.Services;

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
@@ -1,6 +1,6 @@
-﻿using System.Net;
-using System.Text;
-using Newtonsoft.Json;
+﻿using System.Text;
+using Shared.Results;
+using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
@@ -22,7 +22,7 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
     private readonly Func<String, String> BaseAddressResolver;
 
     public ConfigurationService(Func<String, String> baseAddressResolver,
-                                HttpClient httpClient) : base(httpClient) {
+                                HttpClient httpClient, Func<Object,String> serialise, Func<String,Type, Object> deserialise) : base(httpClient, serialise, deserialise) {
         this.BaseAddressResolver = baseAddressResolver;
     }
 
@@ -36,19 +36,19 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
         return requestUri;
     }
 
-    protected override async Task<String> HandleResponse(HttpResponseMessage responseMessage,
-                                                         CancellationToken cancellationToken)
-    {
-        String content = await responseMessage.Content.ReadAsStringAsync();
+    //protected override async Task<String> HandleResponse(HttpResponseMessage responseMessage,
+    //                                                     CancellationToken cancellationToken)
+    //{
+    //    String content = await responseMessage.Content.ReadAsStringAsync();
 
-        if (responseMessage.StatusCode == HttpStatusCode.NotFound)
-        {
-            // No error as maybe running under CI (which has no internet)
-            return content;
-        }
+    //    if (responseMessage.StatusCode == HttpStatusCode.NotFound)
+    //    {
+    //        // No error as maybe running under CI (which has no internet)
+    //        return content;
+    //    }
 
-        return await base.HandleResponse(responseMessage, cancellationToken);
-    }
+    //    return await base.HandleResponse(responseMessage, cancellationToken);
+    //}
 
     public async Task<Result<Configuration>> GetConfiguration(String deviceIdentifier,
                                                               CancellationToken cancellationToken)
@@ -60,33 +60,27 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
         {
             Logger.LogInformation($"About to request configuration for device identifier {deviceIdentifier}");
             Logger.LogDebug($"Configuration Request details: Uri {requestUri}");
-
-            // Make the Http Call here
-            HttpResponseMessage httpResponse = await this.HttpClient.GetAsync(requestUri, cancellationToken);
-            Logger.LogDebug($"Configuration Response [{httpResponse.StatusCode}]");
-                
-            // Process the response
-            String content = await this.HandleResponse(httpResponse, cancellationToken);
-            Logger.LogDebug($"Configuration Response Content [{content}]");
-
+            
             // call was successful so now deserialise the body to the response object
-            ConfigurationResponse apiResponse = JsonConvert.DeserializeObject<ConfigurationResponse>(content);
+            Result<ConfigurationResponse>? apiResponse = await this.Get<ConfigurationResponse>(requestUri, cancellationToken);
+            if (apiResponse.IsFailed)
+                return ResultHelpers.CreateFailure(apiResponse);
 
             Logger.LogDebug($"About to build Configuration");
             response = new Configuration() {
-                ClientSecret = apiResponse.ClientSecret,
-                ClientId = apiResponse.ClientId,
-                ApplicationUpdateUri = apiResponse.ApplicationUpdateUri,
-                EnableAutoUpdates = apiResponse.EnableAutoUpdates,
-                SecurityServiceUri = apiResponse.HostAddresses.Single(h => h.ServiceType == ServiceType.Security).Uri,
+                ClientSecret = apiResponse.Data.ClientSecret,
+                ClientId = apiResponse.Data.ClientId,
+                ApplicationUpdateUri = apiResponse.Data.ApplicationUpdateUri,
+                EnableAutoUpdates = apiResponse.Data.EnableAutoUpdates,
+                SecurityServiceUri = apiResponse.Data.HostAddresses.Single(h => h.ServiceType == ServiceType.Security).Uri,
                 TransactionProcessorAclUri =
-                    apiResponse.HostAddresses.Single(h => h.ServiceType == ServiceType.TransactionProcessorAcl).Uri,
-                LogMessageBatchSize = apiResponse.LogMessageBatchSize.GetValueOrDefault(),
-                SentryDsn = apiResponse.SentryDsn ?? String.Empty,
+                    apiResponse.Data.HostAddresses.Single(h => h.ServiceType == ServiceType.TransactionProcessorAcl).Uri,
+                LogMessageBatchSize = apiResponse.Data.LogMessageBatchSize.GetValueOrDefault(),
+                SentryDsn = apiResponse.Data.SentryDsn ?? String.Empty,
             };
 
             Logger.LogDebug($"About to xlate log level");
-            response.LogLevel = apiResponse.LogLevel switch
+            response.LogLevel = apiResponse.Data.LogLevel switch
             {
                 LoggingLevel.Debug => LogLevel.Debug,
                 LoggingLevel.Error => LogLevel.Error,
@@ -98,7 +92,7 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
             };
 
             Logger.LogInformation($"Configuration for device identifier {deviceIdentifier} requested successfully");
-            Logger.LogDebug($"Configuration Response: [{content}]");
+            Logger.LogDebug($"Configuration Response: [{StringSerialiser.Serialise(apiResponse.Data)}]");
 
             return Result.Success(response);
         }
@@ -122,10 +116,10 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
         {
             messages = logMessages
         };
-        StringContent content = new StringContent(JsonConvert.SerializeObject(container), Encoding.UTF8, "application/json");
+        StringContent content = new(StringSerialiser.Serialise(container), Encoding.UTF8, "application/json");
 
-        HttpResponseMessage httpResponse = await this.HttpClient.PostAsync(requestUri, content, cancellationToken);
+        Result? result = await this.Post(requestUri, content, cancellationToken);
 
-        await this.HandleResponse(httpResponse, cancellationToken);
+        // TODO: return the result to the caller so that we can retry if it fails (and also log any errors that occur here)
     }
 }

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
@@ -1,9 +1,9 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Shared.Results;
-using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
 using TransactionProcessorACL.DataTransferObjects.Responses;
 using ProductType = TransactionProcessor.Mobile.BusinessLogic.Models.ProductType;

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
@@ -153,7 +153,7 @@ public class MerchantService : ClientProxyBase.ClientProxyBase, IMerchantService
         ////ResponseData<MerchantResponse> responseData = this.HandleResponseContent<MerchantResponse>(content.Data);
         //MerchantResponse responseData = JsonConvert.DeserializeObject<MerchantResponse>(content.Data);
 
-        Result<MerchantResponse>? responseDataResult = await this.Get<MerchantResponse>(requestUri, cancellationToken);
+        Result<MerchantResponse>? responseDataResult = await this.Get<MerchantResponse>(requestUri, accessToken.AccessToken, cancellationToken);
 
         if (responseDataResult.IsFailed)
         {

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Net.Http.Headers;
-using ClientProxyBase;
-using Newtonsoft.Json;
+using Shared.Results;
+using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
@@ -39,7 +38,10 @@ public class MerchantService : ClientProxyBase.ClientProxyBase, IMerchantService
     public MerchantService(Func<String, String> baseAddressResolver,
                            HttpClient httpClient,
                            IApplicationCache applicationCache,
-                           IApplicationInfoService applicationInfoService) : base(httpClient) {
+                           IApplicationInfoService applicationInfoService, 
+                           Func<Object, String> serialise, 
+                           Func<String, Type, Object> deserialise) : base(httpClient, serialise, deserialise)
+    {
         this.BaseAddressResolver = baseAddressResolver;
         this.ApplicationCache = applicationCache;
         this.ApplicationInfoService = applicationInfoService;
@@ -68,28 +70,19 @@ public class MerchantService : ClientProxyBase.ClientProxyBase, IMerchantService
         Logger.LogInformation("About to request merchant contracts");
         Logger.LogDebug($"Merchant Contract Request details: Access Token {accessToken.AccessToken}");
 
-        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.AccessToken);
-        var httpResponse = await this.HttpClient.SendAsync(request, cancellationToken);
+        Result<List<ContractResponse>>? responseDataResult = await this.Get<List<ContractResponse>>(requestUri, cancellationToken);
 
-        // Process the response
-        Result<String> content = await this.HandleResponseX(httpResponse, cancellationToken);
-
-        if (content.IsFailed) {
-            Logger.LogInformation($"GetMerchantContracts failed {content.Status}");
-            return Result.Failure(content.Message);
+        if (responseDataResult.IsFailed) {
+            Logger.LogInformation($"GetMerchantContracts failed {responseDataResult.Status}");
+            return ResultHelpers.CreateFailure(responseDataResult);
         }
 
-        Logger.LogDebug($"Transaction Response details:  Status {httpResponse.StatusCode} Payload {content.Data}");
+        Logger.LogInformation($"{responseDataResult.Data.Count} for merchant requested successfully");
+        Logger.LogDebug($"Merchant Contract Response: [{StringSerialiser.Serialise(responseDataResult.Data)}]");
 
-        List<ContractResponse>? responseData = JsonConvert.DeserializeObject<List<ContractResponse>>(content.Data);
-
-        Logger.LogInformation($"{responseData.Count} for merchant requested successfully");
-        Logger.LogDebug($"Merchant Contract Response: [{JsonConvert.SerializeObject(responseData)}]");
-
-        foreach (ContractResponse contractResponse in responseData) {
+        foreach (ContractResponse contractResponse in responseDataResult.Data) {
             foreach (ContractProduct contractResponseProduct in contractResponse.Products) {
-                var productType = GetProductType(contractResponse.OperatorName);
+                ProductType productType = GetProductType(contractResponse.OperatorName);
 
                 models.Add(new ContractProductModel {
                     OperatorId = contractResponse.OperatorId,
@@ -142,48 +135,57 @@ public class MerchantService : ClientProxyBase.ClientProxyBase, IMerchantService
         Logger.LogInformation("About to request merchant details");
         Logger.LogDebug($"Merchant Details Request details: Access Token {accessToken.AccessToken}");
 
-        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.AccessToken);
-        var httpResponse = await this.HttpClient.SendAsync(request, cancellationToken);
+        //HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        //request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.AccessToken);
+        //var httpResponse = await this.HttpClient.SendAsync(request, cancellationToken);
 
-        // Process the response
-        Result<String> content = await this.HandleResponseX(httpResponse, cancellationToken);
+        //// Process the response
+        //Result<String> content = await this.HandleResponseX(httpResponse, cancellationToken);
 
-        if (content.IsFailed)
+        //if (content.IsFailed)
+        //{
+        //    Logger.LogInformation($"GetMerchantContracts failed {content.Status}");
+        //    return Result.Failure(content.Message);
+        //}
+
+        //Logger.LogDebug($"Transaction Response details:  Status {httpResponse.StatusCode} Payload {content.Data}");
+
+        ////ResponseData<MerchantResponse> responseData = this.HandleResponseContent<MerchantResponse>(content.Data);
+        //MerchantResponse responseData = JsonConvert.DeserializeObject<MerchantResponse>(content.Data);
+
+        Result<MerchantResponse>? responseDataResult = await this.Get<MerchantResponse>(requestUri, cancellationToken);
+
+        if (responseDataResult.IsFailed)
         {
-            Logger.LogInformation($"GetMerchantContracts failed {content.Status}");
-            return Result.Failure(content.Message);
+            Logger.LogInformation($"GetMerchantContracts failed {responseDataResult.Status}");
+            return ResultHelpers.CreateFailure(responseDataResult);
         }
 
-        Logger.LogDebug($"Transaction Response details:  Status {httpResponse.StatusCode} Payload {content.Data}");
-
-        //ResponseData<MerchantResponse> responseData = this.HandleResponseContent<MerchantResponse>(content.Data);
-        MerchantResponse responseData = JsonConvert.DeserializeObject<MerchantResponse>(content.Data);
         Logger.LogInformation("Merchant details requested successfully");
-        Logger.LogDebug($"Merchant Details Response: [{JsonConvert.SerializeObject(responseData)}]");
-
+        Logger.LogDebug($"Merchant Details Response: [{StringSerialiser.Serialise(responseDataResult.Data)}]");
+        
         MerchantDetailsModel model = new MerchantDetailsModel {
-                                                                  EstateId = responseData.EstateId,
-                                                                  MerchantId = responseData.MerchantId,
-                                                                  MerchantName = responseData.MerchantName,
-                                                                  NextStatementDate = responseData.NextStatementDate,
+                                                                  EstateId = responseDataResult.Data.EstateId,
+                                                                  MerchantId = responseDataResult.Data.MerchantId,
+                                                                  MerchantName = responseDataResult.Data.MerchantName,
+                                                                  NextStatementDate = responseDataResult.Data.NextStatementDate,
                                                                   LastStatementDate = new DateTime(),
-                                                                  SettlementSchedule = responseData.SettlementSchedule.ToString(),
+                                                                  SettlementSchedule = responseDataResult.Data.SettlementSchedule.ToString(),
                                                                   //AvailableBalance = merchantResponse.AvailableBalance,
                                                                   //Balance = merchantResponse.Balance,
                                                                   Contact = new ContactModel {
-                                                                                                 Name = responseData.Contacts.First().ContactName,
-                                                                                                 EmailAddress = responseData.Contacts.First().ContactEmailAddress,
-                                                                                                 MobileNumber = responseData.Contacts.First().ContactPhoneNumber
+                                                                                                 Name = responseDataResult.Data.Contacts.First().ContactName,
+                                                                                                 EmailAddress = responseDataResult.Data.Contacts.First().ContactEmailAddress,
+                                                                                                 MobileNumber = responseDataResult.Data.Contacts.First().ContactPhoneNumber
                                                                                              },
                                                                   Address = new AddressModel {
-                                                                                                 AddressLine3 = responseData.Addresses.First().AddressLine3,
-                                                                                                 Town = responseData.Addresses.First().Town,
-                                                                                                 AddressLine4 = responseData.Addresses.First().AddressLine4,
-                                                                                                 PostalCode = responseData.Addresses.First().PostalCode,
-                                                                                                 Region = responseData.Addresses.First().Region,
-                                                                                                 AddressLine1 = responseData.Addresses.First().AddressLine1,
-                                                                                                 AddressLine2 = responseData.Addresses.First().AddressLine2
+                                                                                                 AddressLine3 = responseDataResult.Data.Addresses.First().AddressLine3,
+                                                                                                 Town = responseDataResult.Data.Addresses.First().Town,
+                                                                                                 AddressLine4 = responseDataResult.Data.Addresses.First().AddressLine4,
+                                                                                                 PostalCode = responseDataResult.Data.Addresses.First().PostalCode,
+                                                                                                 Region = responseDataResult.Data.Addresses.First().Region,
+                                                                                                 AddressLine1 = responseDataResult.Data.Addresses.First().AddressLine1,
+                                                                                                 AddressLine2 = responseDataResult.Data.Addresses.First().AddressLine2
                                                                                              }
                                                               };
 

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
@@ -70,7 +70,7 @@ public class MerchantService : ClientProxyBase.ClientProxyBase, IMerchantService
         Logger.LogInformation("About to request merchant contracts");
         Logger.LogDebug($"Merchant Contract Request details: Access Token {accessToken.AccessToken}");
 
-        Result<List<ContractResponse>>? responseDataResult = await this.Get<List<ContractResponse>>(requestUri, cancellationToken);
+        Result<List<ContractResponse>>? responseDataResult = await this.Get<List<ContractResponse>>(requestUri, accessToken.AccessToken, cancellationToken);
 
         if (responseDataResult.IsFailed) {
             Logger.LogInformation($"GetMerchantContracts failed {responseDataResult.Status}");

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/TransactionService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/TransactionService.cs
@@ -1,8 +1,8 @@
-﻿using Shared.Serialisation;
-using SimpleResults;
+﻿using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Common;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 using TransactionProcessorACL.DataTransferObjects;
 using TransactionProcessorACL.DataTransferObjects.Responses;
 

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/TransactionService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/TransactionService.cs
@@ -1,8 +1,4 @@
-﻿using System.Net;
-using System.Net.Http.Headers;
-using System.Text;
-using ClientProxyBase;
-using Newtonsoft.Json;
+﻿using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Common;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
@@ -47,12 +43,10 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
 
         public TransactionService(Func<String, String> baseAddressResolver,
                                   HttpClient httpClient,
-                                  IApplicationCache applicationCache) : base(httpClient) {
+                                  IApplicationCache applicationCache, Func<Object, String> serialise, 
+                                  Func<String, Type, Object> deserialise) : base(httpClient, serialise, deserialise) {
             this.BaseAddressResolver = baseAddressResolver;
             this.ApplicationCache = applicationCache;
-
-            // Add the API version header
-            this.HttpClient.DefaultRequestHeaders.Add("api-version", "1.0");
         }
 
         #endregion
@@ -189,15 +183,6 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
 
             return Result.Success(responseModel);
         }
-        
-        protected override async Task<Result<String>> HandleResponseX(HttpResponseMessage responseMessage,
-                                                                      CancellationToken cancellationToken) {
-            if (responseMessage.StatusCode == HttpStatusCode.HttpVersionNotSupported) {
-                throw new ApplicationException("Application needs to be updated to the latest version");
-            }
-
-            return await base.HandleResponseX(responseMessage, cancellationToken);
-        }
 
         private String BuildRequestUrl(String route) {
             String baseAddress = this.BaseAddressResolver("TransactionProcessorACL");
@@ -212,33 +197,23 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
                                                                                           CancellationToken cancellationToken) {
             String requestUri = this.BuildRequestUrl(route);
             try {
-                String requestSerialised = JsonConvert.SerializeObject(request);
-
-                StringContent httpContent = new StringContent(requestSerialised, Encoding.UTF8, "application/json");
-
+                String requestSerialised = StringSerialiser.Serialise(request);
+                
                 // Add the access token to the client headers
                 TokenResponseModel accessToken = this.ApplicationCache.GetAccessToken();
 
                 Logger.LogDebug($"Transaction Request details: Uri {requestUri} Payload {requestSerialised} Access Token {accessToken.AccessToken}");
 
-                this.HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.AccessToken);
-
-                // Make the Http Call here
-                HttpResponseMessage httpResponse = await this.HttpClient.PostAsync(requestUri, httpContent, cancellationToken);
-
-                // Process the response
-                Result<String> result = await this.HandleResponseX(httpResponse, cancellationToken);
+                Result<TResponse>? result = await this.Post<TRequest, TResponse>(requestUri, request, accessToken.AccessToken, cancellationToken);
 
                 if (result.IsSuccess == false) {
-                    Logger.LogWarning("Error performing Voucher transaction");
-                    return Result.Failure("Error performing Voucher transaction");
+                    Logger.LogWarning("Error performing transaction");
+                    return Result.Failure("Error performing transaction");
                 }
 
-                Logger.LogDebug($"Transaction Response details:  Status {httpResponse.StatusCode} Payload {result.Data}");
+                Logger.LogDebug($"Transaction Response details: Payload {StringSerialiser.Serialise(result.Data)}");
 
-                var responseData = JsonConvert.DeserializeObject<TResponse>(result.Data);
-
-                return Result.Success(responseData);
+                return Result.Success(result.Data);
             }
             catch (Exception ex) {
                 // An exception has occurred, add some additional information to the message

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/UpdateService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/UpdateService.cs
@@ -1,5 +1,5 @@
-﻿using System.Text;
-using Newtonsoft.Json;
+﻿using Shared.Results;
+using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
@@ -25,7 +25,8 @@ public class UpdateService : ClientProxyBase.ClientProxyBase, IUpdateService
     private readonly Func<String, String> BaseAddressResolver;
 
     public UpdateService(Func<String, String> baseAddressResolver,
-                         HttpClient httpClient) : base(httpClient)
+                         HttpClient httpClient, Func<Object, String> serialise,
+                         Func<String, Type, Object> deserialise) : base(httpClient, serialise, deserialise)
     {
         this.BaseAddressResolver = baseAddressResolver;
     }
@@ -44,22 +45,16 @@ public class UpdateService : ClientProxyBase.ClientProxyBase, IUpdateService
             Logger.LogInformation($"About to check for application updates for device identifier {deviceIdentifier}");
             Logger.LogDebug($"Application update request details: Uri {requestUri}");
 
-            using StringContent content = new(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
-            using HttpResponseMessage httpResponse = await this.HttpClient.PostAsync(requestUri, content, cancellationToken);
-            Logger.LogDebug($"Application update response [{httpResponse.StatusCode}]");
+            Result<ApplicationUpdateCheckResponse>? result = await this.Post<ApplicationUpdateCheckRequest, ApplicationUpdateCheckResponse>(requestUri, request, cancellationToken);
 
-            String responseContent = await this.HandleResponse(httpResponse, cancellationToken);
-            Logger.LogDebug($"Application update response content [{responseContent}]");
-
-            ApplicationUpdateCheckResponse? response = JsonConvert.DeserializeObject<ApplicationUpdateCheckResponse>(responseContent);
-
-            if (response == null)
-            {
-                return Result.Failure("Application update check did not return a valid response.");
+            if (result.IsFailed) {
+                return ResultHelpers.CreateFailure(result);
             }
 
+            Logger.LogDebug($"Application update response content [{StringSerialiser.Serialise(result.Data)}]");
+            
             Logger.LogInformation($"Application update check for device identifier {deviceIdentifier} completed successfully");
-            return Result.Success(response);
+            return Result.Success(result.Data);
         }
         catch (Exception ex)
         {

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/UpdateService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/UpdateService.cs
@@ -1,8 +1,8 @@
 ﻿using Shared.Results;
-using Shared.Serialisation;
 using SimpleResults;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 
 namespace TransactionProcessor.Mobile.BusinessLogic.Services;
 

--- a/TransactionProcessor.Mobile.BusinessLogic/TransactionProcessor.Mobile.BusinessLogic.csproj
+++ b/TransactionProcessor.Mobile.BusinessLogic/TransactionProcessor.Mobile.BusinessLogic.csproj
@@ -10,9 +10,6 @@
     <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
-    <PackageReference Include="Shared" Version="2026.5.6">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageReference Include="SQLitePCLRaw.core" Version="3.0.2" />
     <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="3.0.2" />

--- a/TransactionProcessor.Mobile.BusinessLogic/TransactionProcessor.Mobile.BusinessLogic.csproj
+++ b/TransactionProcessor.Mobile.BusinessLogic/TransactionProcessor.Mobile.BusinessLogic.csproj
@@ -7,16 +7,21 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
-    <PackageReference Include="SecurityService.Client" Version="2025.12.1" />
+    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
+    <PackageReference Include="Shared" Version="2026.5.6">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageReference Include="SQLitePCLRaw.core" Version="3.0.2" />
     <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="3.0.2" />
     <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
     <PackageReference Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="3.0.2" />
-    <PackageReference Include="Shared.Results" Version="2025.12.1" />
-    <PackageReference Include="TransactionProcessorACL.DataTransferObjects" Version="2025.12.2-build87" />
+    <PackageReference Include="Shared.Results" Version="2026.5.6">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="TransactionProcessorACL.DataTransferObjects" Version="2026.4.3-build129" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
   </ItemGroup>

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
@@ -1,8 +1,10 @@
 ﻿using CommunityToolkit.Mvvm.Input;
 using MediatR;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using MvvmHelpers.Commands;
+using Newtonsoft.Json.Linq;
 using SimpleResults;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -110,10 +112,31 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels
 
             if (tokenResult.IsSuccess) {
                 // Cache the token
+                int index = 1;
+                foreach (var chunk in SplitToken(tokenResult.Data.AccessToken, 50))
+                {
+                    Logger.LogInformation($"JWT Chunk {index++}: {chunk}");
+                }
+
+
                 this.CacheAccessToken(tokenResult.Data);
             }
 
             return tokenResult;
+        }
+
+        public static IEnumerable<string> SplitToken(string token, int chunkSize = 100)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+                yield break;
+
+            if (chunkSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(chunkSize));
+
+            for (int i = 0; i < token.Length; i += chunkSize)
+            {
+                yield return token.Substring(i, Math.Min(chunkSize, token.Length - i));
+            }
         }
 
         private async Task<Result<PerformLogonResponseModel>> PerformLogonTransaction() {

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
@@ -112,33 +112,12 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels
 
             if (tokenResult.IsSuccess) {
                 // Cache the token
-                int index = 1;
-                foreach (var chunk in SplitToken(tokenResult.Data.AccessToken, 50))
-                {
-                    Logger.LogInformation($"JWT Chunk {index++}: {chunk}");
-                }
-
-
                 this.CacheAccessToken(tokenResult.Data);
             }
 
             return tokenResult;
         }
-
-        public static IEnumerable<string> SplitToken(string token, int chunkSize = 100)
-        {
-            if (string.IsNullOrWhiteSpace(token))
-                yield break;
-
-            if (chunkSize <= 0)
-                throw new ArgumentOutOfRangeException(nameof(chunkSize));
-
-            for (int i = 0; i < token.Length; i += chunkSize)
-            {
-                yield return token.Substring(i, Math.Min(chunkSize, token.Length - i));
-            }
-        }
-
+        
         private async Task<Result<PerformLogonResponseModel>> PerformLogonTransaction() {
             // Logon Transaction
             TransactionCommands.PerformLogonCommand command = new(DateTime.Now);

--- a/TransactionProcessor.Mobile.UITests/Common/DockerHelper.cs
+++ b/TransactionProcessor.Mobile.UITests/Common/DockerHelper.cs
@@ -1,7 +1,4 @@
-﻿using System.Net;
-using System.Net.Sockets;
-using System.Runtime.InteropServices;
-using DotNet.Testcontainers.Builders;
+﻿using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
 using EventStore.Client;
@@ -10,7 +7,11 @@ using SecurityService.Client;
 using Shared.IntegrationTesting;
 using Shared.IntegrationTesting.TestContainers;
 using Shared.Logger;
+using Shared.Serialisation;
 using Shouldly;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using TransactionProcessor.Client;
 using TransactionProcessor.DataTransferObjects.Responses.Contract;
 using TransactionProcessor.IntegrationTesting.Helpers;
@@ -54,6 +55,7 @@ namespace TransactionProcessor.Mobile.UITests.Common
         public DockerHelper()
         {
             this.TestingContext = new TestingContext();
+            StringSerialiser.Initialise((IStringSerialiser)new SystemTextJsonSerializer(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions()));
         }
 
         #endregion
@@ -107,6 +109,16 @@ namespace TransactionProcessor.Mobile.UITests.Common
             }
         }
 
+        String Serialise(Object arg)
+        {
+            return StringSerialiser.Serialise<Object>(arg, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+        }
+
+        Object Deserialise(String arg, Type type)
+        {
+            return StringSerialiser.DeserializeObject<Object>(arg, type, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+        }
+
         /// <summary>
         /// Starts the containers for scenario run.
         /// </summary>
@@ -144,8 +156,8 @@ namespace TransactionProcessor.Mobile.UITests.Common
 
                                               };
             HttpClient httpClient = new HttpClient(clientHandler);
-            this.SecurityServiceClient = new SecurityServiceClient(this.SecurityServiceBaseAddressResolver, httpClient);
-            this.TransactionProcessorClient = new TransactionProcessorClient(this.TransactionProcessorBaseAddressResolver, httpClient);
+            this.SecurityServiceClient = new SecurityServiceClient(this.SecurityServiceBaseAddressResolver, httpClient, Serialise, Deserialise);
+            this.TransactionProcessorClient = new TransactionProcessorClient(this.TransactionProcessorBaseAddressResolver, httpClient, Serialise, Deserialise);
 
             this.HttpClient = new HttpClient();
             this.HttpClient.BaseAddress = new Uri(this.TransactionProcessorAclBaseAddressResolver(string.Empty));
@@ -234,7 +246,7 @@ namespace TransactionProcessor.Mobile.UITests.Common
             this.Estates = new List<EstateDetails>();
             this.Clients = new List<ClientDetails>();
             this.Users = new Dictionary<String, Guid>();
-            this.Roles = new Dictionary<String, Guid>();
+            this.Roles = new Dictionary<String, String>();
             this.ApiResources = new List<String>();
         }
 
@@ -266,7 +278,7 @@ namespace TransactionProcessor.Mobile.UITests.Common
         /// </value>
         public NlogLogger Logger { get; set; }
         public Dictionary<String, Guid> Users;
-        public Dictionary<String, Guid> Roles;
+        public Dictionary<String, String> Roles;
         public List<String> ApiResources;
         //public List<String> IdentityResources;
 

--- a/TransactionProcessor.Mobile.UITests/Steps/SharedSteps.cs
+++ b/TransactionProcessor.Mobile.UITests/Steps/SharedSteps.cs
@@ -1,14 +1,15 @@
-﻿using System.Net;
-using System.Text;
-using System.Text.Json;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Reqnroll;
-using SecurityService.DataTransferObjects.Requests;
+using SecurityService.DataTransferObjects;
 using SecurityService.IntegrationTesting.Helpers;
 using Shared.IntegrationTesting;
+using Shared.Serialisation;
 using Shouldly;
-using TransactionProcessor.Database.Contexts;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Text;
+using System.Text.Json;
 using TransactionProcessor.DataTransferObjects.Requests.Contract;
 using TransactionProcessor.DataTransferObjects.Requests.Estate;
 using TransactionProcessor.DataTransferObjects.Requests.Merchant;
@@ -19,6 +20,7 @@ using TransactionProcessor.DataTransferObjects.Responses.Merchant;
 using TransactionProcessor.IntegrationTesting.Helpers;
 using TransactionProcessor.Mobile.UITests.Common;
 using TransactionProcessor.Mobile.UITests.Pages;
+using TransactionProcessor.ProjectionEngine.Database.Database.Entities;
 using AssignOperatorRequest = TransactionProcessor.DataTransferObjects.Requests.Estate.AssignOperatorRequest;
 
 namespace TransactionProcessor.Mobile.UITests.Steps
@@ -51,9 +53,9 @@ namespace TransactionProcessor.Mobile.UITests.Steps
         public async Task GivenTheFollowingSecurityRolesExist(DataTable table)
         {
             List<CreateRoleRequest> requests = table.Rows.ToCreateRoleRequests();
-            List<(String, Guid)> responses = await this.SecurityServiceSteps.GivenICreateTheFollowingRoles(requests, CancellationToken.None);
+            List<(String, String)> responses = await this.SecurityServiceSteps.GivenICreateTheFollowingRoles(requests, CancellationToken.None);
 
-            foreach ((String, Guid) response in responses)
+            foreach ((String, String) response in responses)
             {
                 this.TestingContext.Roles.Add(response.Item1, response.Item2);
             }
@@ -219,7 +221,7 @@ namespace TransactionProcessor.Mobile.UITests.Steps
             });
 
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, $"http://127.0.0.1:{this.TestingContext.DockerHelper.ConfigHostPort}/api/transactionmobileconfiguration");
-            request.Content = new StringContent(JsonConvert.SerializeObject(configRequest), Encoding.UTF8, "application/json");
+            request.Content = new StringContent(StringSerialiser.Serialise(configRequest), Encoding.UTF8, "application/json");
 
             HttpClientHandler clientHandler = new HttpClientHandler
                                               {
@@ -274,10 +276,8 @@ namespace TransactionProcessor.Mobile.UITests.Steps
 
         private async Task<Decimal> GetMerchantBalance(Guid merchantId)
         {
-            JsonElement jsonElement = (JsonElement)await this.TestingContext.DockerHelper.ProjectionManagementClient.GetStateAsync<dynamic>("MerchantBalanceProjection", $"MerchantBalance-{merchantId:N}");
-            JObject jsonObject = JObject.Parse(jsonElement.GetRawText());
-            decimal balanceValue = jsonObject.SelectToken("merchant.balance").Value<decimal>();
-            return balanceValue;
+            MerchantBalanceProjectionState1 balanceState = await this.TestingContext.DockerHelper.ProjectionManagementClient.GetStateAsync<MerchantBalanceProjectionState1>("MerchantBalanceProjection", $"MerchantBalance-{merchantId:N}");
+            return balanceState.merchant.balance;
         }
 
         [Given(@"I make the following manual merchant deposits")]
@@ -346,3 +346,9 @@ namespace TransactionProcessor.Mobile.UITests.Steps
         }
     }
 }
+
+[ExcludeFromCodeCoverage]
+public record Merchant(string Id, string Name, int numberOfEventsProcessed, decimal balance);
+
+[ExcludeFromCodeCoverage]
+public record MerchantBalanceProjectionState1(Merchant merchant);

--- a/TransactionProcessor.Mobile.UITests/Steps/SharedSteps.cs
+++ b/TransactionProcessor.Mobile.UITests/Steps/SharedSteps.cs
@@ -201,22 +201,22 @@ namespace TransactionProcessor.Mobile.UITests.Steps
             ClientDetails clientDetails = this.TestingContext.GetClientDetails("mobileAppClient");
             //ClientDetails clientDetails = ClientDetails.Create("clientId-mobileAppClient", "secret-mobile", new List<String>());
             var configRequest = new {
-                                        clientId = clientDetails.ClientId,
-                                        clientSecret = clientDetails.ClientSecret,
-                                        deviceIdentifier = deviceSerial,
+                                        client_id = clientDetails.ClientId,
+                                        client_secret = clientDetails.ClientSecret,
+                                        device_identifier = deviceSerial,
                                         id = deviceSerial,
-                                        enableAutoUpdates = false,
-                                        logLevel = 3,
-                                        hostAddresses = new List<Object>()
+                                        enable_auto_updates = false,
+                                        log_level = 3,
+                                        host_addresses = new List<Object>()
                                     };
-            configRequest.hostAddresses.Add(new
+            configRequest.host_addresses.Add(new
                                             {
                                                 servicetype = 1,
                                                 uri = this.TestingContext.DockerHelper.SecurityServiceBaseAddressResolver("").Replace("127.0.0.1", this.TestingContext.DockerHelper.LocalIPAddress)
             });
-            configRequest.hostAddresses.Add(new
+            configRequest.host_addresses.Add(new
                                             {
-                                                servicetype = 2,
+                                                service_type = 2,
                                                 uri = this.TestingContext.DockerHelper.TransactionProcessorAclBaseAddressResolver("").Replace("127.0.0.1", this.TestingContext.DockerHelper.LocalIPAddress)
             });
 

--- a/TransactionProcessor.Mobile.UITests/Steps/SharedSteps.cs
+++ b/TransactionProcessor.Mobile.UITests/Steps/SharedSteps.cs
@@ -342,7 +342,25 @@ namespace TransactionProcessor.Mobile.UITests.Steps
         public async Task GivenTheFollowingMetersAreAvailableAtThePataPawaPrePayHost(DataTable table)
         {
             List<ReqnrollExtensions.PataPawaMeter> meters = table.Rows.ToPataPawaMeters();
-            await this.TransactionProcessorSteps.GivenTheFollowingMetersAreAvailableAtThePataPawaPrePaidHost(meters);
+            await this.GivenTheFollowingMetersAreAvailableAtThePataPawaPrePaidHost(meters);
+        }
+
+        public async Task GivenTheFollowingMetersAreAvailableAtThePataPawaPrePaidHost(List<ReqnrollExtensions.PataPawaMeter> meters)
+        {
+            await this.SendRequestToTestHost<ReqnrollExtensions.PataPawaMeter>(meters, "/api/developer/patapawaprepay/createmeter");
+        }
+
+        public async Task SendRequestToTestHost<T>(List<T> objects, String url)
+        {
+            foreach (T o in objects)
+            {
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, url);
+
+                httpRequestMessage.Content = new StringContent(StringSerialiser.Serialise(o, new SerialiserOptions(SerialiserPropertyFormat.CamelCase)), Encoding.UTF8, "application/json");
+
+                HttpResponseMessage response = await this.TestingContext.DockerHelper.TestHostHttpClient.SendAsync(httpRequestMessage);
+                response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            }
         }
     }
 }

--- a/TransactionProcessor.Mobile.UITests/TransactionProcessor.Mobile.UITests.csproj
+++ b/TransactionProcessor.Mobile.UITests/TransactionProcessor.Mobile.UITests.csproj
@@ -16,7 +16,7 @@
 	  <PackageReference Include="Appium.WebDriver" Version="8.2.0" />
 	  <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.5" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
+	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
 	  <PackageReference Include="Shouldly" Version="4.3.0" />
 	  <PackageReference Include="NUnit.ConsoleRunner" Version="3.22.0" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
@@ -28,11 +28,11 @@
 	  <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 	  <PackageReference Include="Reqnroll.NUnit" Version="3.3.4" />
 	  <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
-	  <PackageReference Include="TransactionProcessor.Client" Version="2026.4.1" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.1" />
-	  <PackageReference Include="SecurityService.Client" Version="2025.12.1" />
-	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2025.12.1" />
-	  <PackageReference Include="TransactionProcessor.Database" Version="2026.4.1" />
+	  <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build355" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build355" />
+	  <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
+	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build157" />
+	  <PackageReference Include="TransactionProcessor.Database" Version="2026.4.3-build355" />
 	  <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
   </ItemGroup>
 

--- a/TransactionProcessor.Mobile/AppShell.xaml
+++ b/TransactionProcessor.Mobile/AppShell.xaml
@@ -11,6 +11,7 @@
     xmlns:myAccount="clr-namespace:TransactionProcessor.Mobile.Pages.MyAccount"
     xmlns:support="clr-namespace:TransactionProcessor.Mobile.Pages.Support"
     Title="TransactionProcessor.Mobile"
+    Shell.FlyoutBehavior="Disabled"
     Shell.TabBarBackgroundColor="{DynamicResource shellTabBarBackgroundColor}"
     Shell.TabBarForegroundColor="{DynamicResource shellTabBarForegroundColor}"
     Shell.TabBarTitleColor="{DynamicResource shellTabBarForegroundColor}"

--- a/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
+++ b/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
@@ -1,11 +1,8 @@
 ﻿using System.Net.Security;
 using banditoth.MAUI.DeviceId;
-using MediatR;
 using SecurityService.Client;
-using SimpleResults;
 using TransactionMobile.Maui.UIServices;
 using TransactionProcessor.Mobile.BusinessLogic.Database;
-using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.RequestHandlers;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
 using TransactionProcessor.Mobile.BusinessLogic.Services.TrainingModeServices;
@@ -26,10 +23,8 @@ using TransactionProcessor.Mobile.Pages.Transactions.Admin;
 using TransactionProcessor.Mobile.Pages.Transactions.BillPayment;
 using TransactionProcessor.Mobile.Pages.Transactions.MobileTopup;
 using TransactionProcessor.Mobile.Pages.Transactions.Voucher;
-//using TransactionProcessor.Mobile.Platforms.Android;
 using TransactionProcessor.Mobile.UIServices;
-using LogMessage = TransactionProcessor.Mobile.BusinessLogic.Models.LogMessage;
-using ClientProxyBase;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 
 
 #if ANDROID
@@ -94,7 +89,15 @@ namespace TransactionProcessor.Mobile.Extensions {
             builder.Services.RegisterHttpClientX<ISecurityServiceClient, SecurityServiceClient>();
             builder.Services.AddSingleton<IApplicationCache, ApplicationCache>();
 
-            builder.ConfigureDeviceIdProvider();
+            builder.Services.AddSingleton<IStringSerialiser, SystemTextJsonSerializer>();
+            builder.Services.AddSingleton<Func<Object, String>>(_ => obj => StringSerialiser.Serialise(obj));
+            builder.Services.AddSingleton<Func<String, Type, Object>>(_ => (str, type) => StringSerialiser.DeserializeObject<Object>(str, type));
+
+                var serialiserSettings = SystemTextJsonSerializer.GetDefaultJsonSerializerOptions();
+
+                builder.Services.AddSingleton(serialiserSettings);
+                
+        builder.ConfigureDeviceIdProvider();
 
             return builder;
         }

--- a/TransactionProcessor.Mobile/MauiProgram.cs
+++ b/TransactionProcessor.Mobile/MauiProgram.cs
@@ -8,6 +8,7 @@ using TransactionProcessor.Mobile.BusinessLogic.UIServices;
 using TransactionProcessor.Mobile.Extensions;
 using TransactionProcessor.Mobile.UIServices;
 using Microsoft.Extensions.DependencyInjection;
+using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
 
 namespace TransactionProcessor.Mobile
 {
@@ -33,6 +34,9 @@ namespace TransactionProcessor.Mobile
             builder.Logging.SetMinimumLevel(LogLevel.Trace);//.AddConsole();
             
             Container = builder.Build();
+
+            var serialiser = Container.Services.GetRequiredService<IStringSerialiser>();
+            StringSerialiser.Initialise(serialiser);
 
             Logger.Initialise(new ConsoleLogger());
 

--- a/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
+++ b/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
@@ -151,20 +151,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<!--<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />-->
 		<PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-        <!-- Removed Microsoft.AspNetCore.Http.Abstractions: not required for MAUI client and causes framework resolution to look for Microsoft.AspNetCore.App runtime packs for Android -->
-		<!--<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.11" />-->
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.11" />
+      <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.20" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.20" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.1" />
 		<PackageReference Include="banditoth.MAUI.DeviceId" Version="1.0.2" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="13.0.0" />
 		<PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.0-rc2" />
 		<PackageReference Include="Sentry.Maui" Version="6.4.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
-		<PackageReference Include="Xamarin.AndroidX.Core" Version="1.17.0" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-android'">

--- a/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
+++ b/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
@@ -152,8 +152,8 @@
 
 	<ItemGroup>
 		<!--<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />-->
-		<PackageReference Include="ClientProxyBase" Version="2025.12.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+		<PackageReference Include="ClientProxyBase" Version="2026.5.6" />
+        <!-- Removed Microsoft.AspNetCore.Http.Abstractions: not required for MAUI client and causes framework resolution to look for Microsoft.AspNetCore.App runtime packs for Android -->
 		<!--<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.11" />-->
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.11" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.1" />

--- a/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
+++ b/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
@@ -155,6 +155,7 @@
       <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.20" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.20" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.1" />
+      <PackageReference Include="Shared.Results" Version="2026.5.6" />
 		<PackageReference Include="banditoth.MAUI.DeviceId" Version="1.0.2" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="13.0.0" />
 		<PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.0-rc2" />


### PR DESCRIPTION
Replaced Newtonsoft.Json with Shared.Serialisation and SystemTextJsonSerializer across all projects. Updated service classes and tests to use injected serialization delegates. Upgraded multiple NuGet dependencies. Refactored DockerHelper and integration tests for new serialization and string-based role IDs. Removed obsolete code and unnecessary usings. Dropped Microsoft.AspNetCore.Http.Abstractions from MAUI project to resolve Android issues.

closes #556 