### PR TITLE
Clean up unused code and standardize navigation

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic/Common/IdGenerationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Common/IdGenerationService.cs
@@ -1,34 +1,5 @@
 ﻿namespace TransactionProcessor.Mobile.BusinessLogic.Common
 {
-    /*public class IdGenerationService
-    {
-        internal delegate Guid GenerateUniqueIdFromObject(Object payload);
-
-        internal delegate Guid GenerateUniqueIdFromString(String payload);
-
-
-        private static readonly JsonSerialiser JsonSerialiser = new(() => new JsonSerializerSettings
-                                                                          {
-                                                                              Formatting = Formatting.None
-                                                                          });
-
-        private static readonly GenerateUniqueIdFromObject GenerateUniqueId =
-            data => IdGenerationService.GenerateGuidFromString(IdGenerationService.JsonSerialiser.Serialise(data));
-
-        private static readonly GenerateUniqueIdFromString GenerateGuidFromString = uniqueKey => {
-                                                                                        using SHA256 sha256Hash = SHA256.Create();
-                                                                                        //Generate hash from the key
-                                                                                        Byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(uniqueKey));
-
-                                                                                        Byte[] j = bytes.Skip(Math.Max(0, bytes.Count() - 16)).ToArray(); //Take last 16
-
-                                                                                        //Create our Guid.
-                                                                                        return new Guid(j);
-                                                                                    };
-
-        public static Guid GenerateGuid(Object o) => IdGenerationService.GenerateUniqueId(o);
-    }*/
-
     public static class CorrelationIdProvider
     {
         private static readonly AsyncLocal<string?> _correlationId = new();
@@ -47,13 +18,6 @@
             set => _correlationId.Value = value;
         }
 
-        //public static string? CorrelationId
-        //{
-        //    get => _correlationId.Value;
-        //    set => _correlationId.Value = value;
-        //}
-
-        //public static void New() => CorrelationId = Guid.NewGuid().ToString();
         public static void NewId() => CorrelationId = Guid.NewGuid().ToString();
     }
 }

--- a/TransactionProcessor.Mobile.BusinessLogic/Models/LogMessageModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Models/LogMessageModel.cs
@@ -1,13 +1,10 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
 namespace TransactionProcessor.Mobile.BusinessLogic.Models;
-//using Microsoft.Maui.Graphics;
 
 [ExcludeFromCodeCoverage]
 public class LogMessageModel
 {
-    #region Properties
-
     public DateTime EntryDateTime { get; set; }
 
     public Int32 Id { get; set; }
@@ -17,20 +14,4 @@ public class LogMessageModel
     public String LogLevelString { get; set; }
 
     public String Message { get; set; }
-
-    //public Color TextColor {
-    //    get {
-    //        return this.LogLevel switch {
-    //            LogLevel.Debug => Colors.Gray,
-    //            LogLevel.Trace => Colors.Gray,
-    //            LogLevel.Info => Colors.Blue,
-    //            LogLevel.Warn => Colors.Orange,
-    //            LogLevel.Error => Colors.Red,
-    //            LogLevel.Fatal => Colors.Red,
-    //            _ => Colors.Gray
-    //        };
-    //    }
-    //}
-
-    #endregion
 }

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/ConfigurationService.cs
@@ -35,21 +35,7 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
 
         return requestUri;
     }
-
-    //protected override async Task<String> HandleResponse(HttpResponseMessage responseMessage,
-    //                                                     CancellationToken cancellationToken)
-    //{
-    //    String content = await responseMessage.Content.ReadAsStringAsync();
-
-    //    if (responseMessage.StatusCode == HttpStatusCode.NotFound)
-    //    {
-    //        // No error as maybe running under CI (which has no internet)
-    //        return content;
-    //    }
-
-    //    return await base.HandleResponse(responseMessage, cancellationToken);
-    //}
-
+    
     public async Task<Result<Configuration>> GetConfiguration(String deviceIdentifier,
                                                               CancellationToken cancellationToken)
     {
@@ -66,17 +52,6 @@ public class ConfigurationService : ClientProxyBase.ClientProxyBase, IConfigurat
             if (apiResponse.IsFailed)
                 return ResultHelpers.CreateFailure(apiResponse);
 
-            //response = new Configuration
-            //{
-            //    ApplicationUpdateUri = "",
-            //    ClientId = "mobileAppClient",
-            //    ClientSecret = "d192cbc46d834d0da90e8a9d50ded543",
-            //    EnableAutoUpdates = false,
-            //    LogLevel = LogLevel.Debug,
-            //    SecurityServiceUri = "https://192.168.1.86:5001",
-            //    TransactionProcessorAclUri = "http://192.168.1.86:5003",
-            //};
-            //return response;
             Logger.LogDebug($"Configuration Response is {StringSerialiser.Serialise(apiResponse.Data)}");
             Logger.LogDebug($"About to build Configuration");
             response = new Configuration() {

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/MerchantService.cs
@@ -110,15 +110,7 @@ public class MerchantService : ClientProxyBase.ClientProxyBase, IMerchantService
             Logger.LogInformation("About to request merchant balance");
             Logger.LogDebug($"Merchant Balance Request details: Access Token {accessToken.AccessToken}");
 
-            //MerchantBalanceResponse merchantBalance = new MerchantBalanceResponse {
-            //                                                                          AvailableBalance = 0,
-            //                                                                          Balance = 0
-            //                                                                      };
-            //await this.EstateClient.GetMerchantBalance(accessToken.AccessToken, estateId, merchantId, cancellationToken);
-
             Logger.LogInformation("Balance for merchant requested successfully");
-            //Logger.LogDebug($"Merchant Balance Response: [{JsonConvert.SerializeObject(merchantBalance)}]");
-
             return Result.Success(0.0m);
         }
         catch(Exception ex) {
@@ -134,24 +126,6 @@ public class MerchantService : ClientProxyBase.ClientProxyBase, IMerchantService
 
         Logger.LogInformation("About to request merchant details");
         Logger.LogDebug($"Merchant Details Request details: Access Token {accessToken.AccessToken}");
-
-        //HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-        //request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.AccessToken);
-        //var httpResponse = await this.HttpClient.SendAsync(request, cancellationToken);
-
-        //// Process the response
-        //Result<String> content = await this.HandleResponseX(httpResponse, cancellationToken);
-
-        //if (content.IsFailed)
-        //{
-        //    Logger.LogInformation($"GetMerchantContracts failed {content.Status}");
-        //    return Result.Failure(content.Message);
-        //}
-
-        //Logger.LogDebug($"Transaction Response details:  Status {httpResponse.StatusCode} Payload {content.Data}");
-
-        ////ResponseData<MerchantResponse> responseData = this.HandleResponseContent<MerchantResponse>(content.Data);
-        //MerchantResponse responseData = JsonConvert.DeserializeObject<MerchantResponse>(content.Data);
 
         Result<MerchantResponse>? responseDataResult = await this.Get<MerchantResponse>(requestUri, accessToken.AccessToken, cancellationToken);
 
@@ -171,8 +145,6 @@ public class MerchantService : ClientProxyBase.ClientProxyBase, IMerchantService
                                                                   NextStatementDate = responseDataResult.Data.NextStatementDate,
                                                                   LastStatementDate = new DateTime(),
                                                                   SettlementSchedule = responseDataResult.Data.SettlementSchedule.ToString(),
-                                                                  //AvailableBalance = merchantResponse.AvailableBalance,
-                                                                  //Balance = merchantResponse.Balance,
                                                                   Contact = new ContactModel {
                                                                                                  Name = responseDataResult.Data.Contacts.First().ContactName,
                                                                                                  EmailAddress = responseDataResult.Data.Contacts.First().ContactEmailAddress,

--- a/TransactionProcessor.Mobile.BusinessLogic/UIServices/IDialogService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/UIServices/IDialogService.cs
@@ -26,15 +26,6 @@ public interface IDialogService
                               TimeSpan? duration = null,
                               CancellationToken cancellationToken = default);
 
-    //Task<String> ShowPrompt(String title,
-    //                        String message,
-    //                        String acceptString,
-    //                        String cancelString,
-    //                        String placeHolder = "",
-    //                        Int32 maxLength = -1,
-    //                        Keyboard keyboard = null,
-    //                        String initialValue = "");
-
     Task ShowWarningToast(String message,
                           Action? action = null,
                           String? actionButtonText = "OK",

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
@@ -246,11 +246,8 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels
                 Result<List<ContractProductModel>> getMerchantContractProductsResult = await this.GetMerchantContractProducts();
                 this.HandleResult(getMerchantContractProductsResult);
 
-                //await this.WriteTimingTrace(sw, "After GetMerchantContractProducts");
-                //Result<Decimal> getMerchantBalanceResult =  await this.GetMerchantBalance();
-                //this.HandleResult(getMerchantBalanceResult);
-
-                //await this.WriteTimingTrace(sw, "After GetMerchantBalance");
+                await this.WriteTimingTrace(sw, "After GetMerchantContractProducts");
+                
                 this.ApplicationCache.SetIsLoggedIn(true);
                 
                 this.BalanceRefresher.StartRefreshing();

--- a/TransactionProcessor.Mobile/App.xaml.cs
+++ b/TransactionProcessor.Mobile/App.xaml.cs
@@ -153,8 +153,6 @@ namespace TransactionProcessor.Mobile
 #endif
             MainPage = new AppShell();
 
-            //RegisterRouteOnce("login", typeof(LoginPage));
-            //RegisterRouteOnce("home", typeof(HomePage));
 
             RegisterRouteOnce(nameof(MobileTopupSelectOperatorPage), typeof(MobileTopupSelectOperatorPage));
             RegisterRouteOnce(nameof(MobileTopupSelectProductPage), typeof(MobileTopupSelectProductPage));

--- a/TransactionProcessor.Mobile/AppShell.xaml.cs
+++ b/TransactionProcessor.Mobile/AppShell.xaml.cs
@@ -13,8 +13,6 @@ namespace TransactionProcessor.Mobile
         protected override async void OnNavigating(ShellNavigatingEventArgs args)
         {
             base.OnNavigating(args);
-
-            //Logger.LogDebug($"In OnNavigating - Source [{args.Source.ToString()}] {JsonConvert.SerializeObject(args)}");
             if (args.Source == ShellNavigationSource.ShellSectionChanged)
             {
                 List<Page> existingPages = Navigation.NavigationStack.ToList();

--- a/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
+++ b/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net.Security;
 using banditoth.MAUI.DeviceId;
 using SecurityService.Client;
-using TransactionMobile.Maui.UIServices;
 using TransactionProcessor.Mobile.BusinessLogic.Database;
 using TransactionProcessor.Mobile.BusinessLogic.RequestHandlers;
 using TransactionProcessor.Mobile.BusinessLogic.Services;
@@ -186,32 +185,8 @@ namespace TransactionProcessor.Mobile.Extensions {
         }
 
         public static MauiAppBuilder ConfigureRequestHandlers(this MauiAppBuilder builder) {
-            //builder.Services.AddSingleton<MediatRServiceConfiguration>();
-            //builder.Services.AddSingleton<ISender, Mediator>();
-            //builder.Services.AddSingleton<IPublisher, Mediator>();
-            //builder.Services.AddSingleton<IMediator, Mediator>();
             builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(LoginRequestHandler).Assembly));
-            //builder.Services.AddSingleton<IRequestHandler<GetConfigurationRequest, Result<Configuration>>, LoginRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<LoginRequest, Result<TokenResponseModel>>, LoginRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<RefreshTokenRequest, Result<TokenResponseModel>>, LoginRequestHandler>();
-
-            //builder.Services.AddSingleton<IRequestHandler<GetContractProductsRequest, Result<List<ContractProductModel>>>, MerchantRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<GetProductOperators, Result<List<ContractOperatorModel>>>, MerchantRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<GetMerchantBalanceRequest, Result<Decimal>>, MerchantRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<GetMerchantDetailsRequest, Result<MerchantDetailsModel>>, MerchantRequestHandler>();
-
-            //builder.Services.AddSingleton<IRequestHandler<PerformMobileTopupRequest, Result<PerformMobileTopupResponseModel>>, TransactionRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<LogonTransactionRequest, Result<PerformLogonResponseModel>>, TransactionRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<PerformVoucherIssueRequest, Result<PerformVoucherIssueResponseModel>>, TransactionRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<PerformReconciliationRequest, Result<PerformReconciliationResponseModel>>, TransactionRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentGetAccountRequest, Result<PerformBillPaymentGetAccountResponseModel>>, TransactionRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentGetMeterRequest, Result<PerformBillPaymentGetMeterResponseModel>>, TransactionRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentMakePostPaymentRequest, Result<PerformBillPaymentMakePaymentResponseModel>>, TransactionRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<PerformBillPaymentMakePrePaymentRequest, Result<PerformBillPaymentMakePaymentResponseModel>>, TransactionRequestHandler>();
-
-            //builder.Services.AddSingleton<IRequestHandler<UploadLogsRequest, Boolean>, SupportRequestHandler>();
-            //builder.Services.AddSingleton<IRequestHandler<ViewLogsRequest, List<LogMessage>>, SupportRequestHandler>();
-
+           
             return builder;
         }
 

--- a/TransactionProcessor.Mobile/MauiProgram.cs
+++ b/TransactionProcessor.Mobile/MauiProgram.cs
@@ -31,7 +31,7 @@ namespace TransactionProcessor.Mobile
             }).Services.AddTransient<IDeviceService, DeviceService>()
                 .AddMemoryCache();
 
-            builder.Logging.SetMinimumLevel(LogLevel.Trace);//.AddConsole();
+            builder.Logging.SetMinimumLevel(LogLevel.Trace);;
             
             Container = builder.Build();
 

--- a/TransactionProcessor.Mobile/Pages/MyAccount/MyAccountAddressesPage.xaml.cs
+++ b/TransactionProcessor.Mobile/Pages/MyAccount/MyAccountAddressesPage.xaml.cs
@@ -16,20 +16,5 @@ public partial class MyAccountAddressesPage : ContentPage
     {
         base.OnAppearing();
         await this.viewModel.Initialise(CancellationToken.None);
-
-        //this.AddressLine2.IsVisible = String.IsNullOrEmpty(viewModel.Address.AddressLine2) switch {
-        //    true => false,
-        //    false => true
-        //};
-        //this.AddressLine3.IsVisible = String.IsNullOrEmpty(viewModel.Address.AddressLine3) switch
-        //{
-        //    true => false,
-        //    false => true
-        //};
-        //this.AddressLine4.IsVisible = String.IsNullOrEmpty(viewModel.Address.AddressLine4) switch
-        //{
-        //    true => false,
-        //    false => true
-        //};
     }
 }

--- a/TransactionProcessor.Mobile/UIServices/DialogService.cs
+++ b/TransactionProcessor.Mobile/UIServices/DialogService.cs
@@ -1,12 +1,8 @@
-﻿using Microsoft.Maui.Controls;
+﻿using CommunityToolkit.Maui.Alerts;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
-using TransactionProcessor.Mobile.UIServices;
 
-namespace TransactionMobile.Maui.UIServices
+namespace TransactionProcessor.Mobile.UIServices
 {
-    using CommunityToolkit.Maui.Alerts;
-    using CommunityToolkit.Maui.Core;
-
     public class DialogService : IDialogService
     {
         #region Methods
@@ -52,17 +48,6 @@ namespace TransactionMobile.Maui.UIServices
                                                                SnackBarOptionsHelper.GetInfoSnackbarOptions,
                                                                cancellationToken);
         }
-
-        //public async Task<String> ShowPrompt(String title,
-        //                                     String message,
-        //                                     String acceptString,
-        //                                     String cancelString,
-        //                                     String placeHolder = "",
-        //                                     Int32 maxLength = -1,
-        //                                     Keyboard keyboard = null,
-        //                                     String initialValue = "") {
-        //    return await Application.Current.MainPage.DisplayPromptAsync(title, message, acceptString, cancelString, placeHolder, maxLength, keyboard, initialValue);
-        //}
 
         public async Task ShowWarningToast(String message,
                                            Action? action = null,

--- a/TransactionProcessor.Mobile/UIServices/ShellNavigationService.cs
+++ b/TransactionProcessor.Mobile/UIServices/ShellNavigationService.cs
@@ -1,5 +1,4 @@
-﻿using TransactionProcessor.Mobile;
-using TransactionProcessor.Mobile.BusinessLogic.Logging;
+﻿using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.UIServices;
 using TransactionProcessor.Mobile.BusinessLogic.ViewModels.Transactions;
 using TransactionProcessor.Mobile.Pages.MyAccount;
@@ -10,7 +9,7 @@ using TransactionProcessor.Mobile.Pages.Transactions.BillPayment;
 using TransactionProcessor.Mobile.Pages.Transactions.MobileTopup;
 using TransactionProcessor.Mobile.Pages.Transactions.Voucher;
 
-namespace TransactionMobile.Maui.UIServices;
+namespace TransactionProcessor.Mobile.UIServices;
 
 public class ShellNavigationService : INavigationService
 {
@@ -37,11 +36,11 @@ public class ShellNavigationService : INavigationService
     }
 
     public async Task GoToHome() {
-        await NavigateTo("///main/home");
+        await this.NavigateTo("///main/home");
     }
 
     public async Task GoToMobileTopupFailedPage() {
-        await NavigateTo($"{nameof(MobileTopupFailedPage)}");
+        await this.NavigateTo($"{nameof(MobileTopupFailedPage)}");
     }
 
     public async Task GoToMobileTopupPerformTopupPage(ProductDetails productDetails,
@@ -51,53 +50,53 @@ public class ShellNavigationService : INavigationService
                                                                             {nameof(ProductDetails), productDetails},
                                                                         };
 
-        await NavigateTo($"{nameof(MobileTopupPerformTopupPage)}", d);
+        await this.NavigateTo($"{nameof(MobileTopupPerformTopupPage)}", d);
     }
 
     public async Task GoToMobileTopupSelectOperatorPage() {
-        await NavigateTo($"{nameof(MobileTopupSelectOperatorPage)}");
+        await this.NavigateTo($"{nameof(MobileTopupSelectOperatorPage)}");
     }
 
     public async Task GoToBillPaymentSelectOperatorPage() {
-        await NavigateTo($"{nameof(BillPaymentSelectOperatorPage)}");
+        await this.NavigateTo($"{nameof(BillPaymentSelectOperatorPage)}");
     }
 
     public async Task GoToBillPaymentSelectProductPage(ProductDetails productDetails) {
         Dictionary<String, Object> d = new Dictionary<String, Object>() {
                                                                             {nameof(ProductDetails), productDetails},
                                                                         };
-        await NavigateTo($"{nameof(BillPaymentSelectProductPage)}",d);
+        await this.NavigateTo($"{nameof(BillPaymentSelectProductPage)}",d);
     }
 
     public async Task GoToAdminPage() {
-        await NavigateTo(nameof(AdminPage));
+        await this.NavigateTo(nameof(AdminPage));
     }
 
     public async Task GoToMobileTopupSelectProductPage(ProductDetails productDetails) {
         Dictionary<String, Object> d = new Dictionary<String, Object>() {
                                                                             {nameof(ProductDetails), productDetails},
                                                                         };
-        await NavigateTo($"{nameof(MobileTopupSelectProductPage)}", d);
+        await this.NavigateTo($"{nameof(MobileTopupSelectProductPage)}", d);
     }
 
     public async Task GoToMobileTopupSuccessPage() {
-        await NavigateTo($"{nameof(MobileTopupSuccessPage)}");
+        await this.NavigateTo($"{nameof(MobileTopupSuccessPage)}");
     }
 
     public async Task GoToVoucherIssueSuccessPage() {
-        await NavigateTo($"{nameof(VoucherIssueSuccessPage)}");
+        await this.NavigateTo($"{nameof(VoucherIssueSuccessPage)}");
     }
 
     public async Task GoToVoucherIssueFailedPage() {
-        await NavigateTo($"{nameof(VoucherIssueFailedPage)}");
+        await this.NavigateTo($"{nameof(VoucherIssueFailedPage)}");
     }
 
     public async Task GoToBillPaymentSuccessPage() {
-        await NavigateTo($"{nameof(BillPaymentSuccessPage)}");
+        await this.NavigateTo($"{nameof(BillPaymentSuccessPage)}");
     }
 
     public async Task GoToBillPaymentFailedPage() {
-        await NavigateTo($"{nameof(BillPaymentFailedPage)}");
+        await this.NavigateTo($"{nameof(BillPaymentFailedPage)}");
     }
 
     public async Task PopToRoot() {
@@ -106,7 +105,7 @@ public class ShellNavigationService : INavigationService
     }
 
     public async Task GoToVoucherSelectOperatorPage() {
-        await NavigateTo(nameof(VoucherSelectOperatorPage));
+        await this.NavigateTo(nameof(VoucherSelectOperatorPage));
     }
 
     public async Task GoToVoucherSelectProductPage(ProductDetails productDetails) {
@@ -115,7 +114,7 @@ public class ShellNavigationService : INavigationService
                                                                             {nameof(ProductDetails), productDetails},
                                                                         };
 
-        await NavigateTo($"{nameof(VoucherSelectProductPage)}", d);
+        await this.NavigateTo($"{nameof(VoucherSelectProductPage)}", d);
     }
 
     public async Task GoToVoucherIssueVoucherPage(ProductDetails productDetails,
@@ -124,7 +123,7 @@ public class ShellNavigationService : INavigationService
                                                                             {"VoucherAmount", voucherAmount},
                                                                             {nameof(ProductDetails), productDetails},
                                                                         };
-        await NavigateTo($"{nameof(VoucherPerformIssuePage)}", d);
+        await this.NavigateTo($"{nameof(VoucherPerformIssuePage)}", d);
     }
 
     public async Task GoToBillPaymentGetAccountPage(ProductDetails productDetails) {
@@ -132,14 +131,14 @@ public class ShellNavigationService : INavigationService
         Dictionary<String, Object> d = new Dictionary<String, Object>() {
                                                                             {nameof(ProductDetails), productDetails},
                                                                         };
-        await NavigateTo($"{nameof(BillPaymentGetAccountPage)}", d);
+        await this.NavigateTo($"{nameof(BillPaymentGetAccountPage)}", d);
     }
 
     public async Task GoToBillPaymentGetMeterPage(ProductDetails productDetails){
         Dictionary<String, Object> d = new Dictionary<String, Object>() {
                                                                             {nameof(ProductDetails), productDetails},
                                                                         };
-        await NavigateTo($"{nameof(BillPaymentGetMeterPage)}", d);
+        await this.NavigateTo($"{nameof(BillPaymentGetMeterPage)}", d);
     }
 
     public async Task GoToBillPaymentPayBillPage(ProductDetails productDetails,
@@ -149,7 +148,7 @@ public class ShellNavigationService : INavigationService
                                                                             {nameof(BillDetails), billDetails}
                                                                         };
 
-        await NavigateTo($"{nameof(BillPaymentPayBillPage)}", d);
+        await this.NavigateTo($"{nameof(BillPaymentPayBillPage)}", d);
     }
 
     public async Task GoToBillPaymentPayBillPage(ProductDetails productDetails,
@@ -160,41 +159,41 @@ public class ShellNavigationService : INavigationService
                                                                             {nameof(MeterDetails), meterDetails}
                                                                         };
 
-        await NavigateTo($"{nameof(BillPaymentPayBillPage)}", d);
+        await this.NavigateTo($"{nameof(BillPaymentPayBillPage)}", d);
     }
 
     public async Task GoToLoginPage() {
         Application.Current.MainPage = new AppShell();
-        await NavigateTo("///login");
+        await this.NavigateTo("///login");
     }
 
     public async Task GoToViewLogsPage() {
-        await NavigateTo(nameof(ViewLogsPage));
+        await this.NavigateTo(nameof(ViewLogsPage));
     }
 
     public async Task GoToMyAccountAddresses() {
         MyAccountAddressesPage p = (MyAccountAddressesPage)MauiProgram.Container.Services.GetService(typeof(MyAccountAddressesPage));
-        await NavigateTo(p);
+        await this.NavigateTo(p);
     }
 
     public async Task GoToMyAccountContacts() {
-        await NavigateTo(nameof(MyAccountContactPage));
+        await this.NavigateTo(nameof(MyAccountContactPage));
     }
 
     public async Task GoToMyAccountDetails() {
-        await NavigateTo(nameof(MyAccountDetailsPage));
+        await this.NavigateTo(nameof(MyAccountDetailsPage));
     }
 
     public async Task GoToReportsSalesAnalysis(){
-        await NavigateTo(nameof(ReportsSalesAnalysisPage));
+        await this.NavigateTo(nameof(ReportsSalesAnalysisPage));
     }
 
     public async Task GoToReportsBalanceAnalysis(){
-        await NavigateTo(nameof(ReportsBalanceAnalysisPage));
+        await this.NavigateTo(nameof(ReportsBalanceAnalysisPage));
     }
 
     public async Task GoToTransactions() {
-        await NavigateTo("///main/transactions");
+        await this.NavigateTo("///main/transactions");
     }
 
     private async Task NavigateTo(String route) {
@@ -224,7 +223,6 @@ public class ShellNavigationService : INavigationService
     private async Task NavigateTo(ContentPage page){
         try
         {
-            //Logger.LogInformation($"navigating to {route}");
             await Shell.Current.Navigation.PushAsync(page);
         }
         catch (Exception e)


### PR DESCRIPTION
Removed commented-out and legacy code across services, view models, and pages to improve clarity. Updated navigation methods to use this.NavigateTo for consistency. Cleaned up using directives and unified namespace declarations in DialogService and ShellNavigationService. Minor formatting and logging improvements applied throughout.

closes #611 