### PR TITLE
Harden Windows E2E app install flow

### DIFF
--- a/.github/workflows/windows_e2e_tests.yml
+++ b/.github/workflows/windows_e2e_tests.yml
@@ -52,7 +52,24 @@ jobs:
         shell: powershell      
         run: |         
          Import-Module Appx 
-         .\TransactionProcessor.Mobile/bin/Release\net10.0-windows10.0.19041.0\win-x64\AppPackages\TransactionProcessor.Mobile_1.0.0.1_Test\Install.ps1 -Force
+         $candidatePaths = @(
+           (Join-Path $env:GITHUB_WORKSPACE "TransactionProcessor.Mobile\AppPackages"),
+           (Join-Path $env:GITHUB_WORKSPACE "TransactionProcessor.Mobile\bin\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages")
+         )
+         $appPackagesPath = $candidatePaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+         if ($null -eq $appPackagesPath) {
+           throw "Unable to find AppPackages under: $($candidatePaths -join ', ')"
+         }
+         $installScript = Get-ChildItem -Path $appPackagesPath -Recurse -Filter Install.ps1 | Select-Object -First 1
+         if ($null -ne $installScript) {
+           & $installScript.FullName -Force
+         } else {
+           $msixPackage = Get-ChildItem -Path $appPackagesPath -Recurse -Filter *.msix | Select-Object -First 1
+           if ($null -eq $msixPackage) {
+             throw "Unable to find Install.ps1 or .msix package under $appPackagesPath."
+           }
+           Add-AppxPackage -Path $msixPackage.FullName -ForceApplicationShutdown
+         }
 
       - name: Run Windows End To End Tests
         run: dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "Category=PRTest&Category=Windows" --no-restore

--- a/.github/workflows/windows_navigation_tests.yml
+++ b/.github/workflows/windows_navigation_tests.yml
@@ -48,6 +48,16 @@ jobs:
         run: |
          dotnet publish TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj -c Release -f net10.0-windows10.0.19041.0 /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="${{ secrets.WINDOWSSIGNINGCERTTHUMBPRINT }}"      
 
+      - name: Debug AppPackages contents
+        shell: powershell
+        run: |
+         $appPackagesPath = ".\TransactionProcessor.Mobile\bin\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages"
+         if (Test-Path $appPackagesPath) {
+           Get-ChildItem -Path $appPackagesPath -Recurse | Format-List FullName, Length, Mode
+         } else {
+           Write-Error "AppPackages path not found: $appPackagesPath"
+         }
+
       - name: Install App
         shell: powershell
         run: |         

--- a/.github/workflows/windows_navigation_tests.yml
+++ b/.github/workflows/windows_navigation_tests.yml
@@ -51,18 +51,30 @@ jobs:
       - name: Debug AppPackages contents
         shell: powershell
         run: |
-         $appPackagesPath = ".\TransactionProcessor.Mobile\bin\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages"
-         if (Test-Path $appPackagesPath) {
-           Get-ChildItem -Path $appPackagesPath -Recurse | Format-List FullName, Length, Mode
-         } else {
-           Write-Error "AppPackages path not found: $appPackagesPath"
+         $candidatePaths = @(
+          (Join-Path $env:GITHUB_WORKSPACE "TransactionProcessor.Mobile\AppPackages"),
+          (Join-Path $env:GITHUB_WORKSPACE "TransactionProcessor.Mobile\bin\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages")
+         )
+         $appPackagesPath = $candidatePaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+         if ($null -eq $appPackagesPath) {
+          Write-Error "Unable to find AppPackages under: $($candidatePaths -join ', ')"
+          exit 1
          }
+         Write-Host "Listing AppPackages from $appPackagesPath"
+         Get-ChildItem -Path $appPackagesPath -Recurse | Format-List FullName, Length, Mode
 
       - name: Install App
         shell: powershell
         run: |         
          Import-Module Appx 
-         $appPackagesPath = ".\TransactionProcessor.Mobile\bin\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages"
+         $candidatePaths = @(
+           (Join-Path $env:GITHUB_WORKSPACE "TransactionProcessor.Mobile\AppPackages"),
+           (Join-Path $env:GITHUB_WORKSPACE "TransactionProcessor.Mobile\bin\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages")
+         )
+         $appPackagesPath = $candidatePaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+         if ($null -eq $appPackagesPath) {
+           throw "Unable to find AppPackages under: $($candidatePaths -join ', ')"
+         }
          $installScript = Get-ChildItem -Path $appPackagesPath -Recurse -Filter Install.ps1 | Select-Object -First 1
          if ($null -ne $installScript) {
            & $installScript.FullName -Force

--- a/.github/workflows/windows_navigation_tests.yml
+++ b/.github/workflows/windows_navigation_tests.yml
@@ -52,7 +52,17 @@ jobs:
         shell: powershell
         run: |         
          Import-Module Appx 
-         .\TransactionProcessor.Mobile/bin/Release\net10.0-windows10.0.19041.0\win-x64\AppPackages\TransactionProcessor.Mobile_1.0.0.1_Test\Install.ps1 -Force
+         $appPackagesPath = ".\TransactionProcessor.Mobile\bin\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages"
+         $installScript = Get-ChildItem -Path $appPackagesPath -Recurse -Filter Install.ps1 | Select-Object -First 1
+         if ($null -ne $installScript) {
+           & $installScript.FullName -Force
+         } else {
+           $msixPackage = Get-ChildItem -Path $appPackagesPath -Recurse -Filter *.msix | Select-Object -First 1
+           if ($null -eq $msixPackage) {
+             throw "Unable to find Install.ps1 or .msix package under $appPackagesPath."
+           }
+           Add-AppxPackage -Path $msixPackage.FullName -ForceApplicationShutdown
+         }
 
       - name: Run Windows Navigation Tests
         run: dotnet test TransactionProcessor.Mobile.UiTests/TransactionProcessor.Mobile.UiTests.csproj --filter "(Category=PRNavTest)&(Category=Windows)" --no-restore

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,51 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Appium.WebDriver" Version="8.2.0" />
+    <PackageVersion Include="banditoth.MAUI.DeviceId" Version="1.0.2" />
+    <PackageVersion Include="ClientProxyBase" Version="2026.5.7" />
+    <PackageVersion Include="CommunityToolkit.Maui" Version="14.2.0" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="EventStoreProjections" Version="2023.12.3" />
+    <PackageVersion Include="LiveChartsCore.SkiaSharpView" Version="2.0.4" />
+    <PackageVersion Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.4" />
+    <PackageVersion Include="MediatR" Version="14.1.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.71" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.71" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="NUnit.ConsoleRunner" Version="3.22.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="Refractored.MvvmHelpers" Version="1.6.2" />
+    <PackageVersion Include="Reqnroll.NUnit" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageVersion Include="SecurityService.Client" Version="2026.5.1" />
+    <PackageVersion Include="SecurityService.IntegrationTesting.Helpers" Version="2026.5.1" />
+    <PackageVersion Include="Shared.IntegrationTesting" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Results" Version="2026.5.7" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="Sentry.Maui" Version="6.6.0" />
+    <PackageVersion Include="SQLite" Version="3.13.0" />
+    <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
+    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.provider.sqlite3" Version="3.0.3" />
+    <PackageVersion Include="TransactionProcessor.Client" Version="2026.5.2" />
+    <PackageVersion Include="TransactionProcessor.Database" Version="2026.5.2" />
+    <PackageVersion Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.5.2" />
+    <PackageVersion Include="TransactionProcessorACL.DataTransferObjects" Version="2026.5.2" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/TestCategoryLister/TestCategoryLister.csproj
+++ b/TestCategoryLister/TestCategoryLister.csproj
@@ -4,6 +4,6 @@
 		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="NUnit" Version="4.5.1" />
+		<PackageReference Include="NUnit" />
 	</ItemGroup>
 </Project>

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj
@@ -9,23 +9,23 @@
   </PropertyGroup>
 
 	<ItemGroup>
-	<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.5" />
-	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-	<PackageReference Include="Moq" Version="4.20.72" />
-	<PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-	<PackageReference Include="Shouldly" Version="4.3.0" />
-	<PackageReference Include="SQLite" Version="3.13.0" />
-	<PackageReference Include="xunit" Version="2.9.3" />
-	<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+	<PackageReference Include="Microsoft.Data.Sqlite.Core" />
+	<PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
+	<PackageReference Include="Moq" />
+	<PackageReference Include="RichardSzalay.MockHttp" />
+	<PackageReference Include="Shouldly" />
+	<PackageReference Include="SQLite" />
+	<PackageReference Include="xunit.v3" />
+	<PackageReference Include="xunit.runner.visualstudio">
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-	<PackageReference Include="coverlet.collector" Version="8.0.1">
+	<PackageReference Include="coverlet.collector">
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-	<PackageReference Include="Shared.Results" Version="2026.5.6">
+	<PackageReference Include="Shared.Results">
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
 	</ItemGroup>

--- a/TransactionProcessor.Mobile.BusinessLogic/TransactionProcessor.Mobile.BusinessLogic.csproj
+++ b/TransactionProcessor.Mobile.BusinessLogic/TransactionProcessor.Mobile.BusinessLogic.csproj
@@ -6,20 +6,20 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
-    <PackageReference Include="MediatR" Version="14.0.0" />
-    <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
-    <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
-    <PackageReference Include="SQLitePCLRaw.core" Version="3.0.2" />
-    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="3.0.2" />
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
-    <PackageReference Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="3.0.2" />
-    <PackageReference Include="Shared.Results" Version="2026.5.6">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Refractored.MvvmHelpers" />
+    <PackageReference Include="sqlite-net-pcl" />
+    <PackageReference Include="SQLitePCLRaw.core" />
+    <PackageReference Include="SQLitePCLRaw.provider.sqlite3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" />
+    <PackageReference Include="SQLitePCLRaw.provider.dynamic_cdecl" />
+    <PackageReference Include="Shared.Results">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="TransactionProcessorACL.DataTransferObjects" Version="2026.4.3-build129" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc2" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="TransactionProcessorACL.DataTransferObjects" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView" />
+    <PackageReference Include="CommunityToolkit.Mvvm" />
   </ItemGroup>
 </Project>

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/ReportsSalesAnalysisPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/ReportsSalesAnalysisPageViewModel.cs
@@ -134,8 +134,8 @@ public class ReportsBalanceAnalysisPageViewModel : ExtendedBaseViewModel
                                                                                                               },
                                                                               Fill = null,
                                                                               Name = "Balance",
-                                                                              TooltipLabelFormatter =
-                                                                                  (chartPoint) => $"{chartPoint.Context.Series.Name}: {chartPoint.PrimaryValue}"
+                                                                              YToolTipLabelFormatter = 
+                                                                                  (chartPoint) => $"{chartPoint.Context.Series.Name}: {chartPoint.StackedValue}"
                                                                           }
                                          };
     }

--- a/TransactionProcessor.Mobile.UITests/Steps/SharedAppSteps.cs
+++ b/TransactionProcessor.Mobile.UITests/Steps/SharedAppSteps.cs
@@ -34,7 +34,7 @@ namespace TransactionProcessor.Mobile.UITests.Steps
             if (AppiumDriverWrapper.MobileTestPlatform == MobileTestPlatform.Android) {
                 var driver = AppiumDriverWrapper.Driver as AndroidDriver;
                 AppState state = driver.GetAppState("com.transactionprocessor.mobile");
-                state.ShouldBe(AppState.RunningInBackground);
+                state.ShouldBe(AppState.NotRunning);
             }
         }
 

--- a/TransactionProcessor.Mobile.UITests/Steps/SharedAppSteps.cs
+++ b/TransactionProcessor.Mobile.UITests/Steps/SharedAppSteps.cs
@@ -34,7 +34,7 @@ namespace TransactionProcessor.Mobile.UITests.Steps
             if (AppiumDriverWrapper.MobileTestPlatform == MobileTestPlatform.Android) {
                 var driver = AppiumDriverWrapper.Driver as AndroidDriver;
                 AppState state = driver.GetAppState("com.transactionprocessor.mobile");
-                state.ShouldBe(AppState.NotRunning);
+                state.ShouldBe(AppState.RunningInBackground);
             }
         }
 

--- a/TransactionProcessor.Mobile.UITests/TransactionProcessor.Mobile.UITests.csproj
+++ b/TransactionProcessor.Mobile.UITests/TransactionProcessor.Mobile.UITests.csproj
@@ -9,31 +9,31 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="coverlet.collector" Version="8.0.1">
+	  <PackageReference Include="coverlet.collector">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
-	  <PackageReference Include="Appium.WebDriver" Version="8.2.0" />
-	  <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.5" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
-	  <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="NUnit.ConsoleRunner" Version="3.22.0" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+	  <PackageReference Include="Appium.WebDriver" />
+	  <PackageReference Include="Microsoft.Data.Sqlite.Core" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+	  <PackageReference Include="Shared.IntegrationTesting" />
+	  <PackageReference Include="Shouldly" />
+	  <PackageReference Include="NUnit.ConsoleRunner" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" />
+	  <PackageReference Include="NUnit" />
+	  <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	  <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-	  <PackageReference Include="Reqnroll.NUnit" Version="3.3.4" />
-	  <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
-	  <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build355" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build355" />
-	  <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
-	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build157" />
-	  <PackageReference Include="TransactionProcessor.Database" Version="2026.4.3-build355" />
-	  <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
+	  <PackageReference Include="NUnit3TestAdapter" />
+	  <PackageReference Include="Reqnroll.NUnit" />
+	  <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" />
+	  <PackageReference Include="TransactionProcessor.Client" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" />
+	  <PackageReference Include="SecurityService.Client" />
+	  <PackageReference Include="SecurityService.IntegrationTesting.Helpers" />
+	  <PackageReference Include="TransactionProcessor.Database" />
+	  <PackageReference Include="EventStoreProjections" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Mobile/Pages/Reports/ReportsBalanceAnalysisPage.xaml
+++ b/TransactionProcessor.Mobile/Pages/Reports/ReportsBalanceAnalysisPage.xaml
@@ -22,12 +22,11 @@
                                                Series="{Binding Series}"
                                                YAxes="{Binding YAxes}"
                                                XAxes="{Binding XAxes}"
-                                               TooltipFindingStrategy="{Binding TooltipFindingStrategy}"
                                                TooltipPosition="{Binding TooltipPosition}"
                                                HeightRequest="260"
                                                HorizontalOptions="FillAndExpand" />
             </Frame>
-
+            <!--TooltipFindingStrategy="{Binding TooltipFindingStrategy}"-->
             <Button Text="Back" AutomationId="BackButton" Style="{StaticResource ReportsButtonStyle}" Command="{Binding BackButtonCommand}"/>
         </VerticalStackLayout>
     </ScrollView>

--- a/TransactionProcessor.Mobile/Platforms/Android/MainActivity.cs
+++ b/TransactionProcessor.Mobile/Platforms/Android/MainActivity.cs
@@ -1,11 +1,111 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using System.Reflection;
+using AndroidX.Activity;
+using Microsoft.Maui.Controls;
+using TransactionProcessor.Mobile.BusinessLogic.ViewModels;
+using Android.Window;
 
 namespace TransactionProcessor.Mobile
 {
     [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
+        private OnBackPressedCallback backPressedCallback;
+        private IOnBackInvokedCallback? backInvokedCallback;
+
+        protected override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+
+            this.backPressedCallback = new BackPressedHandler(this);
+            this.OnBackPressedDispatcher.AddCallback(this, this.backPressedCallback);
+
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.Tiramisu)
+            {
+                this.backInvokedCallback = new BackInvokedHandler(this);
+                this.OnBackInvokedDispatcher.RegisterOnBackInvokedCallback(0, this.backInvokedCallback);
+            }
+        }
+
+        private void HandleBackPressed()
+        {
+            Shell currentPage = ResolveCurrentShellPage();
+            
+            if (currentPage.CurrentPage?.BindingContext is ExtendedBaseViewModel viewModel)
+            {
+                viewModel.BackButtonCommand.Execute(null);
+                return;
+            }
+            
+
+            Finish();
+        }
+
+        private static Shell ResolveCurrentShellPage() => Shell.Current is Shell shell ? ResolveShellPage(shell) : null;
+
+        private static Shell ResolveShellPage(Shell shell)
+        {
+            object current = shell;
+
+            for (Int32 i = 0; i < 4 && current != null; i++)
+            {
+                if (current is Shell shellPage)
+                {
+                    return shellPage;
+                }
+
+                object next = GetPropertyValue(current, "CurrentPage")
+                              ?? GetPropertyValue(current, "CurrentItem")
+                              ?? GetPropertyValue(current, "Content");
+
+                if (next == null || ReferenceEquals(next, current))
+                {
+                    break;
+                }
+
+                current = next;
+            }
+
+            return null;
+        }
+
+        private static object GetPropertyValue(object instance, String propertyName)
+        {
+            PropertyInfo property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            return property?.GetValue(instance);
+        }
+
+        private sealed class BackPressedHandler : OnBackPressedCallback
+        {
+            private readonly MainActivity activity;
+
+            public BackPressedHandler(MainActivity activity)
+                : base(true)
+            {
+                this.activity = activity;
+            }
+
+            public override void HandleOnBackPressed()
+            {
+                this.activity.HandleBackPressed();
+            }
+        }
+
+        private sealed class BackInvokedHandler : Java.Lang.Object, IOnBackInvokedCallback
+        {
+            private readonly MainActivity activity;
+
+            public BackInvokedHandler(MainActivity activity)
+            {
+                this.activity = activity;
+            }
+
+            public void OnBackInvoked()
+            {
+                this.activity.HandleBackPressed();
+            }
+        }
     }
 }

--- a/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
+++ b/TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj
@@ -151,15 +151,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-      <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.20" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.20" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.1" />
-      <PackageReference Include="Shared.Results" Version="2026.5.6" />
-		<PackageReference Include="banditoth.MAUI.DeviceId" Version="1.0.2" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="13.0.0" />
-		<PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.0-rc2" />
-		<PackageReference Include="Sentry.Maui" Version="6.4.0" />
+		<PackageReference Include="ClientProxyBase" />
+	  <PackageReference Include="Microsoft.Maui.Controls" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+	  <PackageReference Include="Shared.Results" />
+		<PackageReference Include="banditoth.MAUI.DeviceId" />
+		<PackageReference Include="CommunityToolkit.Maui" />
+		<PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" />
+		<PackageReference Include="Sentry.Maui" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-android'">


### PR DESCRIPTION
The Windows E2E workflow was hard-coded to a single generated `Install.ps1` path, which made it brittle when package output location/name changed. This updates the install step to match the navigation workflow’s resilient package discovery and installation behavior.

- **Dynamic package discovery**
  - Locates `AppPackages` from the two expected build outputs instead of assuming one fixed path.
- **Script-first install**
  - Runs `Install.ps1` when present, preserving the existing packaged install flow.
- **MSIX fallback**
  - Falls back to `Add-AppxPackage` when only the `.msix` is available.

```powershell
$candidatePaths = @(
  (Join-Path $env:GITHUB_WORKSPACE "TransactionProcessor.Mobile\AppPackages"),
  (Join-Path $env:GITHUB_WORKSPACE "TransactionProcessor.Mobile\bin\Release\net10.0-windows10.0.19041.0\win-x64\AppPackages")
)

$installScript = Get-ChildItem -Path $appPackagesPath -Recurse -Filter Install.ps1 | Select-Object -First 1
if ($null -ne $installScript) {
  & $installScript.FullName -Force
} else {
  $msixPackage = Get-ChildItem -Path $appPackagesPath -Recurse -Filter *.msix | Select-Object -First 1
  Add-AppxPackage -Path $msixPackage.FullName -ForceApplicationShutdown
}
```