### PR TITLE
Add Recent Activity and Receipt Report feature

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/RequestHandlerTests/ReportRequestHandlerTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/RequestHandlerTests/ReportRequestHandlerTests.cs
@@ -96,4 +96,93 @@ public class ReportRequestHandlerTests
                                   It.IsAny<CancellationToken>()),
                               Times.Once);
     }
+
+    [Fact]
+    public async Task GetRecentActivityReceiptReportQuery_ReturnsMockedResultsForOneDate()
+    {
+        Mock<IReportsService> reportsService = new();
+        Mock<IApplicationCache> applicationCache = new();
+        MerchantDetailsModel merchantDetails = new()
+        {
+            MerchantReportingId = 12345
+        };
+
+        DateTime reportDate = new(2026, 7, 6);
+
+        applicationCache.Setup(a => a.GetMerchantDetails()).Returns(merchantDetails);
+        reportsService.Setup(r => r.GetRecentActivityReceiptReport(
+                                  merchantDetails.MerchantReportingId,
+                                  reportDate,
+                                  "TXN-10001",
+                                  1,
+                                  5,
+                                  It.IsAny<CancellationToken>()))
+                      .ReturnsAsync(Result.Success(RecentActivityReceiptReportModel.CreateMock(reportDate, "TXN-10001")));
+
+        ReportRequestHandler handler = new(reportsService.Object, applicationCache.Object);
+
+        Result<RecentActivityReceiptReportModel> result = await handler.Handle(
+            new ReportQueries.GetRecentActivityReceiptReportQuery(
+                ReportDate: reportDate,
+                SearchText: "TXN-10001",
+                PageNumber: 1,
+                PageSize: 5),
+            CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Data.ReportDate.ShouldBe(reportDate);
+        result.Data.Items.ShouldNotBeEmpty();
+        result.Data.Items.All(item => item.TransactionDateTime.Date == reportDate).ShouldBeTrue();
+        reportsService.Verify(r => r.GetRecentActivityReceiptReport(
+                                  merchantDetails.MerchantReportingId,
+                                  reportDate,
+                                  "TXN-10001",
+                                  1,
+                                  5,
+                                  It.IsAny<CancellationToken>()),
+                              Times.Once);
+    }
+
+    [Fact]
+    public async Task GetRecentActivityReceiptReportQuery_PassesPagingToService()
+    {
+        Mock<IReportsService> reportsService = new();
+        Mock<IApplicationCache> applicationCache = new();
+        MerchantDetailsModel merchantDetails = new()
+        {
+            MerchantReportingId = 12345
+        };
+
+        DateTime reportDate = new(2026, 7, 6);
+
+        applicationCache.Setup(a => a.GetMerchantDetails()).Returns(merchantDetails);
+        reportsService.Setup(r => r.GetRecentActivityReceiptReport(
+                                  merchantDetails.MerchantReportingId,
+                                  reportDate,
+                                  null,
+                                  2,
+                                  5,
+                                  It.IsAny<CancellationToken>()))
+                      .ReturnsAsync(Result.Success(RecentActivityReceiptReportModel.CreateMock(reportDate, null)));
+
+        ReportRequestHandler handler = new(reportsService.Object, applicationCache.Object);
+
+        Result<RecentActivityReceiptReportModel> result = await handler.Handle(
+            new ReportQueries.GetRecentActivityReceiptReportQuery(
+                ReportDate: reportDate,
+                SearchText: null,
+                PageNumber: 2,
+                PageSize: 5),
+            CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        reportsService.Verify(r => r.GetRecentActivityReceiptReport(
+                                  merchantDetails.MerchantReportingId,
+                                  reportDate,
+                                  null,
+                                  2,
+                                  5,
+                                  It.IsAny<CancellationToken>()),
+                              Times.Once);
+    }
 }

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/ReportsServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/ReportsServiceTests.cs
@@ -99,4 +99,176 @@ public class ReportsServiceTests
         requestPayload.ShouldContain("\"merchant_reporting_id\": 12345");
         requestPayload.ShouldContain("\"top_n\": 5");
     }
+
+    [Fact]
+    public async Task GetRecentActivityReceiptReport_SendsRequestAndMapsResponse()
+    {
+        RecentActivityReceiptSearchResponseDto response = new()
+        {
+            ReportDate = new DateTime(2026, 7, 6),
+            PageNumber = 1,
+            PageSize = 5,
+            TotalCount = 2,
+            Items =
+            [
+                new RecentActivityReceiptSearchItemDto
+                {
+                    Reference = "TXN-10002",
+                    TransactionType = "Bill Payment",
+                    Product = "Bill Pay (Post)",
+                    Operator = "PataPawa PostPay",
+                    Status = "Success",
+                    Amount = 250.00m,
+                    TransactionDateTime = new DateTime(2026, 7, 6, 10, 15, 0),
+                    ReceiptReference = "RCPT-10002"
+                },
+                new RecentActivityReceiptSearchItemDto
+                {
+                    Reference = "TXN-10001",
+                    TransactionType = "Mobile Topup",
+                    Product = "Custom",
+                    Operator = "Safaricom",
+                    Status = "Success",
+                    Amount = 100.00m,
+                    TransactionDateTime = new DateTime(2026, 7, 6, 9, 30, 0),
+                    ReceiptReference = "RCPT-10001"
+                }
+            ]
+        };
+
+        String requestPayload = string.Empty;
+        this.MockHttpMessageHandler.When(HttpMethod.Post, "http://localhost/api/reporting/recentactivityreceiptsearch")
+            .Respond(req =>
+            {
+                requestPayload = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(StringSerialiser.Serialise(response), Encoding.UTF8, "application/json")
+                };
+            });
+
+        Result<RecentActivityReceiptReportModel> result = await this.ReportsService.GetRecentActivityReceiptReport(12345,
+                                                                                                              new DateTime(2026, 7, 6),
+                                                                                                              "TXN-10001",
+                                                                                                              1,
+                                                                                                              5,
+                                                                                                              CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Data.ReportDate.ShouldBe(new DateTime(2026, 7, 6));
+        result.Data.Items.Count.ShouldBe(2);
+        result.Data.Items[0].Reference.ShouldBe("TXN-10002");
+        result.Data.Items[1].Reference.ShouldBe("TXN-10001");
+        result.Data.PageNumber.ShouldBe(1);
+        result.Data.PageSize.ShouldBe(5);
+        result.Data.TotalCount.ShouldBe(2);
+        requestPayload.ShouldContain("\"application_version\": \"1.2.3\"");
+        requestPayload.ShouldContain("\"merchant_reporting_id\": 12345");
+        requestPayload.ShouldContain("\"report_date\"");
+        requestPayload.ShouldContain("2026-07-06");
+        requestPayload.ShouldContain("\"search_text\": \"TXN-10001\"");
+    }
+
+    [Fact]
+    public async Task GetRecentActivityReceiptReport_ReturnsSecondPage()
+    {
+        RecentActivityReceiptSearchResponseDto response = new()
+        {
+            ReportDate = new DateTime(2026, 7, 6),
+            PageNumber = 2,
+            PageSize = 5,
+            TotalCount = 10,
+            Items =
+            [
+                new RecentActivityReceiptSearchItemDto
+                {
+                    Reference = "TXN-10005",
+                    TransactionType = "Bill Payment",
+                    Product = "Prepaid Power",
+                    Operator = "KPLC",
+                    Status = "Failed",
+                    Amount = 75.00m,
+                    TransactionDateTime = new DateTime(2026, 7, 6, 13, 5, 0),
+                    ReceiptReference = "RCPT-10005"
+                }
+            ]
+        };
+
+        this.MockHttpMessageHandler.When(HttpMethod.Post, "http://localhost/api/reporting/recentactivityreceiptsearch")
+            .Respond(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(StringSerialiser.Serialise(response), Encoding.UTF8, "application/json")
+            });
+
+        Result<RecentActivityReceiptReportModel> result = await this.ReportsService.GetRecentActivityReceiptReport(12345,
+                                                                                                              new DateTime(2026, 7, 6),
+                                                                                                              null,
+                                                                                                              2,
+                                                                                                              5,
+                                                                                                              CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Data.PageNumber.ShouldBe(2);
+        result.Data.PageSize.ShouldBe(5);
+        result.Data.TotalCount.ShouldBe(10);
+        result.Data.Items.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ResendRecentActivityReceipt_SendsRequestAndMapsSuccessResponse()
+    {
+        RecentActivityReceiptResendResponseDto response = new()
+        {
+            Success = true,
+            Message = "Receipt resend requested.",
+            Reference = "TXN-10001",
+            ReceiptReference = "RCPT-10001",
+            TransactionReference = "TXN-10001"
+        };
+
+        String requestPayload = string.Empty;
+        this.MockHttpMessageHandler.When(HttpMethod.Post, "http://localhost/api/transactions/resendreceipt")
+            .Respond(req =>
+            {
+                requestPayload = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(StringSerialiser.Serialise(response), Encoding.UTF8, "application/json")
+                };
+            });
+
+        Result<RecentActivityReceiptResendResultModel> result = await this.ReportsService.ResendRecentActivityReceipt("TXN-10001",
+                                                                                                                      "customer@example.com",
+                                                                                                                      CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Data.Success.ShouldBeTrue();
+        result.Data.Message.ShouldBe("Receipt resend requested.");
+        result.Data.Reference.ShouldBe("TXN-10001");
+        requestPayload.ShouldContain("\"reference\": \"TXN-10001\"");
+        requestPayload.ShouldContain("\"recipient_email_address\": \"customer@example.com\"");
+    }
+
+    [Fact]
+    public async Task ResendRecentActivityReceipt_ReturnsFailureWhenApiRejectsRequest()
+    {
+        RecentActivityReceiptResendResponseDto response = new()
+        {
+            Success = false,
+            Message = "Recipient email address is not valid."
+        };
+
+        this.MockHttpMessageHandler.When(HttpMethod.Post, "http://localhost/api/transactions/resendreceipt")
+            .Respond(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(StringSerialiser.Serialise(response), Encoding.UTF8, "application/json")
+            });
+
+        Result<RecentActivityReceiptResendResultModel> result = await this.ReportsService.ResendRecentActivityReceipt("TXN-10001",
+                                                                                                                      "invalid@example",
+                                                                                                                      CancellationToken.None);
+
+        result.IsFailed.ShouldBeTrue();
+        result.Message.ShouldBe("Recipient email address is not valid.");
+    }
 }

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Reports/RecentActivityReceiptDetailPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Reports/RecentActivityReceiptDetailPageViewModelTests.cs
@@ -1,0 +1,156 @@
+using Moq;
+using Shouldly;
+using SimpleResults;
+using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Services;
+using TransactionProcessor.Mobile.BusinessLogic.UIServices;
+using TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports;
+
+namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ViewModelTests.Reports;
+
+public class RecentActivityReceiptDetailPageViewModelTests
+{
+    private readonly Mock<INavigationService> NavigationService;
+    private readonly Mock<IApplicationCache> ApplicationCache;
+    private readonly Mock<IDialogService> DialogService;
+    private readonly Mock<IDeviceService> DeviceService;
+    private readonly Mock<INavigationParameterService> NavigationParameterService;
+    private readonly Mock<IReportsService> ReportsService;
+    private readonly RecentActivityReceiptDetailPageViewModel ViewModel;
+
+    public RecentActivityReceiptDetailPageViewModelTests()
+    {
+        this.NavigationService = new Mock<INavigationService>();
+        this.ApplicationCache = new Mock<IApplicationCache>();
+        this.DialogService = new Mock<IDialogService>();
+        this.DeviceService = new Mock<IDeviceService>();
+        this.NavigationParameterService = new Mock<INavigationParameterService>();
+        this.ReportsService = new Mock<IReportsService>();
+        this.ViewModel = new RecentActivityReceiptDetailPageViewModel(this.NavigationService.Object,
+                                                                       this.ApplicationCache.Object,
+                                                                       this.DialogService.Object,
+                                                                       this.DeviceService.Object,
+                                                                       this.NavigationParameterService.Object,
+                                                                       this.ReportsService.Object);
+    }
+
+    [Fact]
+    public async Task Initialise_LoadsSelectedItemFromNavigationParameters()
+    {
+        RecentActivityReceiptItemModel item = new("TXN-10001",
+                                                  "Mobile Topup",
+                                                  "Custom",
+                                                  "Safaricom",
+                                                  "Success",
+                                                  100.00m,
+                                                  new DateTime(2026, 7, 6, 9, 30, 0),
+                                                  "RCPT-10001");
+
+        this.NavigationParameterService.Setup(p => p.GetParameters()).Returns(new Dictionary<string, object>
+        {
+            { nameof(RecentActivityReceiptItemModel), item }
+        });
+
+        await this.ViewModel.Initialise(CancellationToken.None);
+
+        this.ViewModel.Reference.ShouldBe("TXN-10001");
+        this.ViewModel.ReceiptReference.ShouldBe("RCPT-10001");
+        this.ViewModel.HasReceipt.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ResendReceiptCommand_SendsReceiptAndShowsSuccessMessage()
+    {
+        RecentActivityReceiptItemModel item = new("TXN-10001",
+                                                  "Mobile Topup",
+                                                  "Custom",
+                                                  "Safaricom",
+                                                  "Success",
+                                                  100.00m,
+                                                  new DateTime(2026, 7, 6, 9, 30, 0),
+                                                  "RCPT-10001");
+
+        this.NavigationParameterService.Setup(p => p.GetParameters()).Returns(new Dictionary<string, object>
+        {
+            { nameof(RecentActivityReceiptItemModel), item }
+        });
+
+        await this.ViewModel.Initialise(CancellationToken.None);
+
+        this.ViewModel.EmailAddress = "customer@example.com";
+        this.ReportsService.Setup(r => r.ResendRecentActivityReceipt("TXN-10001",
+                                                                     "customer@example.com",
+                                                                     It.IsAny<CancellationToken>()))
+                           .ReturnsAsync(Result.Success(new RecentActivityReceiptResendResultModel
+                           {
+                               Success = true,
+                               Message = "Receipt resend requested.",
+                               Reference = "TXN-10001"
+                           }));
+
+        await this.ViewModel.ResendReceiptCommand.ExecuteAsync(null);
+
+        this.ReportsService.Verify(r => r.ResendRecentActivityReceipt("TXN-10001",
+                                                                      "customer@example.com",
+                                                                      It.IsAny<CancellationToken>()),
+                                   Times.Once);
+        this.DialogService.Verify(d => d.ShowSuccessToast("Receipt resend requested. Sent to customer@example.com.", null, "OK", null, It.IsAny<CancellationToken>()), Times.Once);
+        this.ViewModel.EmailAddress.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public async Task ResendReceiptCommand_ShowsWarningForInvalidEmail()
+    {
+        RecentActivityReceiptItemModel item = new("TXN-10001",
+                                                  "Mobile Topup",
+                                                  "Custom",
+                                                  "Safaricom",
+                                                  "Success",
+                                                  100.00m,
+                                                  new DateTime(2026, 7, 6, 9, 30, 0),
+                                                  "RCPT-10001");
+
+        this.NavigationParameterService.Setup(p => p.GetParameters()).Returns(new Dictionary<string, object>
+        {
+            { nameof(RecentActivityReceiptItemModel), item }
+        });
+
+        await this.ViewModel.Initialise(CancellationToken.None);
+
+        this.ViewModel.EmailAddress = "invalid-email";
+
+        await this.ViewModel.ResendReceiptCommand.ExecuteAsync(null);
+
+        this.DialogService.Verify(d => d.ShowWarningToast("Enter a valid email address before resending the receipt.", null, "OK", null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResendReceiptCommand_ShowsWarningWhenApiFails()
+    {
+        RecentActivityReceiptItemModel item = new("TXN-10001",
+                                                  "Mobile Topup",
+                                                  "Custom",
+                                                  "Safaricom",
+                                                  "Success",
+                                                  100.00m,
+                                                  new DateTime(2026, 7, 6, 9, 30, 0),
+                                                  "RCPT-10001");
+
+        this.NavigationParameterService.Setup(p => p.GetParameters()).Returns(new Dictionary<string, object>
+        {
+            { nameof(RecentActivityReceiptItemModel), item }
+        });
+
+        await this.ViewModel.Initialise(CancellationToken.None);
+
+        this.ViewModel.EmailAddress = "customer@example.com";
+        this.ReportsService.Setup(r => r.ResendRecentActivityReceipt("TXN-10001",
+                                                                     "customer@example.com",
+                                                                     It.IsAny<CancellationToken>()))
+                           .ReturnsAsync(Result.Failure("Receipt resend failed."));
+
+        await this.ViewModel.ResendReceiptCommand.ExecuteAsync(null);
+
+        this.DialogService.Verify(d => d.ShowWarningToast("Receipt resend failed.", null, "OK", null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Reports/RecentActivityReportPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Reports/RecentActivityReportPageViewModelTests.cs
@@ -1,0 +1,95 @@
+using MediatR;
+using Moq;
+using Shouldly;
+using SimpleResults;
+using TransactionProcessor.Mobile.BusinessLogic.Common;
+using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Requests;
+using TransactionProcessor.Mobile.BusinessLogic.Services;
+using TransactionProcessor.Mobile.BusinessLogic.UIServices;
+using TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports;
+
+namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ViewModelTests.Reports;
+
+public class RecentActivityReportPageViewModelTests
+{
+    private readonly Mock<IMediator> Mediator;
+    private readonly Mock<INavigationService> NavigationService;
+    private readonly Mock<IApplicationCache> ApplicationCache;
+    private readonly Mock<IDialogService> DialogService;
+    private readonly Mock<IDeviceService> DeviceService;
+    private readonly Mock<INavigationParameterService> NavigationParameterService;
+    private readonly RecentActivityReportPageViewModel ViewModel;
+
+    public RecentActivityReportPageViewModelTests()
+    {
+        this.Mediator = new Mock<IMediator>();
+        this.NavigationService = new Mock<INavigationService>();
+        this.ApplicationCache = new Mock<IApplicationCache>();
+        this.DialogService = new Mock<IDialogService>();
+        this.DeviceService = new Mock<IDeviceService>();
+        this.NavigationParameterService = new Mock<INavigationParameterService>();
+
+        this.ViewModel = new RecentActivityReportPageViewModel(this.Mediator.Object,
+                                                                this.NavigationService.Object,
+                                                                this.ApplicationCache.Object,
+                                                                this.DialogService.Object,
+                                                                this.DeviceService.Object,
+                                                                this.NavigationParameterService.Object);
+    }
+
+    [Fact]
+    public async Task Initialise_LoadsMockedResultsForToday()
+    {
+        DateTime reportDate = new(2026, 7, 6);
+        this.Mediator
+            .Setup(m => m.Send(It.Is<ReportQueries.GetRecentActivityReceiptReportQuery>(q => q.ReportDate == reportDate && q.SearchText == null && q.PageNumber == 1 && q.PageSize == 5), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(RecentActivityReceiptReportModel.CreateMock(reportDate, null)));
+
+        this.ViewModel.SelectedDate = reportDate;
+
+        await this.ViewModel.Initialise(CancellationToken.None);
+
+        this.ViewModel.SelectedDate.ShouldBe(reportDate);
+        this.ViewModel.Items.Count.ShouldBeGreaterThan(0);
+        this.ViewModel.IsLoading.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SearchCommand_UsesSelectedDateAndSearchText()
+    {
+        DateTime reportDate = new(2026, 7, 6);
+        this.Mediator
+            .Setup(m => m.Send(It.Is<ReportQueries.GetRecentActivityReceiptReportQuery>(q => q.ReportDate == reportDate && q.SearchText == "TXN-10001" && q.PageNumber == 1 && q.PageSize == 5), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(RecentActivityReceiptReportModel.CreateMock(reportDate, "TXN-10001")));
+
+        this.ViewModel.SelectedDate = reportDate;
+        this.ViewModel.SearchText = "TXN-10001";
+
+        await this.ViewModel.SearchCommand.ExecuteAsync(null);
+
+        this.ViewModel.Items.ShouldContain(item => item.Reference == "TXN-10001");
+        this.Mediator.VerifyAll();
+    }
+
+    [Fact]
+    public async Task NextPageCommand_RequestsTheNextPage()
+    {
+        DateTime reportDate = new(2026, 7, 6);
+        this.Mediator
+            .Setup(m => m.Send(It.Is<ReportQueries.GetRecentActivityReceiptReportQuery>(q => q.ReportDate == reportDate && q.PageNumber == 1 && q.PageSize == 5), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(RecentActivityReceiptReportModel.CreateMock(reportDate, null, 1, 5)));
+        this.Mediator
+            .Setup(m => m.Send(It.Is<ReportQueries.GetRecentActivityReceiptReportQuery>(q => q.ReportDate == reportDate && q.PageNumber == 2 && q.PageSize == 5), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(RecentActivityReceiptReportModel.CreateMock(reportDate, null, 2, 5)));
+
+        this.ViewModel.SelectedDate = reportDate;
+
+        await this.ViewModel.Initialise(CancellationToken.None);
+        await this.ViewModel.NextPageCommand.ExecuteAsync(null);
+
+        this.ViewModel.PageNumber.ShouldBe(2);
+        this.ViewModel.Items.ShouldAllBe(item => item.TransactionDateTime.Date == reportDate);
+        this.Mediator.Verify(m => m.Send(It.Is<ReportQueries.GetRecentActivityReceiptReportQuery>(q => q.PageNumber == 2 && q.PageSize == 5), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Reports/ReportsPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Reports/ReportsPageViewModelTests.cs
@@ -66,7 +66,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ViewModelTests.Reports
         public async Task ReportsPageViewModel_Initialise_IsInitialised()
         {
             await this.ViewModel.Initialise(CancellationToken.None);
-            this.ViewModel.ReportsMenuOptions.Count.ShouldBe(2);
+            this.ViewModel.ReportsMenuOptions.Count.ShouldBe(3);
         }
 
         [Fact]
@@ -81,6 +81,20 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ViewModelTests.Reports
             this.ViewModel.OptionSelectedCommand.Execute(itemSelected);
 
             this.NavigationService.Verify(v => v.GoToTransactionMixSummaryPage(), Times.Once);
+        }
+
+        [Fact]
+        public async Task ReportsPageViewModel_RecentActivityCommand_Execute_IsExecuted()
+        {
+            ItemSelected<ListViewItem> itemSelected = new ItemSelected<ListViewItem>
+            {
+                SelectedItem = new ListViewItem { Title = "Recent Activity and Receipt Report" },
+                SelectedItemIndex = 2,
+            };
+
+            this.ViewModel.OptionSelectedCommand.Execute(itemSelected);
+
+            this.NavigationService.Verify(v => v.GoToRecentActivityReportPage(), Times.Once);
         }
 
         [Fact]

--- a/TransactionProcessor.Mobile.BusinessLogic/Models/RecentActivityReceiptReportModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Models/RecentActivityReceiptReportModel.cs
@@ -1,0 +1,82 @@
+namespace TransactionProcessor.Mobile.BusinessLogic.Models;
+
+public sealed record RecentActivityReceiptReportModel
+{
+    public DateTime ReportDate { get; set; }
+
+    public string? SearchText { get; set; }
+
+    public int PageNumber { get; set; }
+
+    public int PageSize { get; set; }
+
+    public int TotalCount { get; set; }
+
+    public IReadOnlyList<RecentActivityReceiptItemModel> Items { get; set; } = [];
+
+    public int TotalPages => this.PageSize <= 0
+        ? 0
+        : (int)Math.Ceiling(this.TotalCount / (decimal)this.PageSize);
+
+    public static RecentActivityReceiptReportModel CreateMock(DateTime reportDate,
+                                                              string? searchText,
+                                                              int pageNumber = 1,
+                                                              int pageSize = 5)
+    {
+        List<RecentActivityReceiptItemModel> items =
+        [
+            new("TXN-10001", "Mobile Topup", "Custom", "Safaricom", "Success", 100.00m, reportDate.Date.AddHours(9).AddMinutes(30), "RCPT-10001"),
+            new("TXN-10002", "Bill Payment", "Bill Pay (Post)", "PataPawa PostPay", "Success", 250.00m, reportDate.Date.AddHours(10).AddMinutes(15), "RCPT-10002"),
+            new("TXN-10003", "Voucher Issue", "10 KES", "Voucher", "Failed", 0.00m, reportDate.Date.AddHours(11).AddMinutes(5), "RCPT-10003"),
+            new("TXN-10004", "Mobile Topup", "Airtime", "Airtel", "Success", 50.00m, reportDate.Date.AddHours(12).AddMinutes(20), "RCPT-10004"),
+            new("TXN-10005", "Bill Payment", "Prepaid Power", "KPLC", "Failed", 75.00m, reportDate.Date.AddHours(13).AddMinutes(5), "RCPT-10005"),
+            new("TXN-10006", "Voucher Issue", "20 KES", "Voucher", "Success", 20.00m, reportDate.Date.AddHours(14).AddMinutes(10), "RCPT-10006"),
+            new("TXN-10007", "Mobile Topup", "Custom", "Safaricom", "Success", 500.00m, reportDate.Date.AddHours(15).AddMinutes(55), "RCPT-10007"),
+        ];
+
+        if (string.IsNullOrWhiteSpace(searchText) == false)
+        {
+            string term = searchText.Trim();
+            items = items.Where(item => item.Matches(term)).ToList();
+        }
+
+        items = items.OrderByDescending(item => item.TransactionDateTime).ToList();
+
+        int normalizedPageSize = pageSize > 0 ? pageSize : 5;
+        int normalizedPageNumber = pageNumber > 0 ? pageNumber : 1;
+        int totalCount = items.Count;
+
+        return new RecentActivityReceiptReportModel
+        {
+            ReportDate = reportDate.Date,
+            SearchText = searchText,
+            PageNumber = normalizedPageNumber,
+            PageSize = normalizedPageSize,
+            TotalCount = totalCount,
+            Items = items.Skip((normalizedPageNumber - 1) * normalizedPageSize)
+                         .Take(normalizedPageSize)
+                         .ToList(),
+        };
+    }
+}
+
+public sealed record RecentActivityReceiptItemModel(string Reference,
+                                                    string TransactionType,
+                                                    string Product,
+                                                    string Operator,
+                                                    string Status,
+                                                    decimal Amount,
+                                                    DateTime TransactionDateTime,
+                                                    string ReceiptReference)
+{
+    public bool Matches(string searchText)
+    {
+        return this.Reference.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+            || this.TransactionType.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+            || this.Product.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+            || this.Operator.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+            || this.Status.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+            || this.ReceiptReference.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+            || this.Amount.ToString("0.##").Contains(searchText, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/TransactionProcessor.Mobile.BusinessLogic/Models/RecentActivityReceiptResendResultModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Models/RecentActivityReceiptResendResultModel.cs
@@ -1,0 +1,14 @@
+namespace TransactionProcessor.Mobile.BusinessLogic.Models;
+
+public sealed record RecentActivityReceiptResendResultModel
+{
+    public bool Success { get; set; }
+
+    public string? Message { get; set; }
+
+    public string? Reference { get; set; }
+
+    public string? ReceiptReference { get; set; }
+
+    public string? TransactionReference { get; set; }
+}

--- a/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/ReportRequestHandler.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/ReportRequestHandler.cs
@@ -7,7 +7,8 @@ using TransactionProcessor.Mobile.BusinessLogic.Services;
 namespace TransactionProcessor.Mobile.BusinessLogic.RequestHandlers;
 
 public sealed class ReportRequestHandler : IRequestHandler<ReportQueries.GetDailyPerformanceSummaryQuery, Result<DailyPerformanceSummaryModel>>,
-                                          IRequestHandler<ReportQueries.GetTransactionMixSummaryQuery, Result<TransactionMixSummaryModel>> {
+                                          IRequestHandler<ReportQueries.GetTransactionMixSummaryQuery, Result<TransactionMixSummaryModel>>,
+                                          IRequestHandler<ReportQueries.GetRecentActivityReceiptReportQuery, Result<RecentActivityReceiptReportModel>> {
     private readonly IReportsService ReportsService;
     private readonly IApplicationCache ApplicationCache;
 
@@ -55,5 +56,22 @@ public sealed class ReportRequestHandler : IRequestHandler<ReportQueries.GetDail
                                                                   request.Measure,
                                                                   request.TopN,
                                                                   cancellationToken);
+    }
+
+    public async Task<Result<RecentActivityReceiptReportModel>> Handle(ReportQueries.GetRecentActivityReceiptReportQuery request,
+                                                                       CancellationToken cancellationToken)
+    {
+        MerchantDetailsModel merchant = this.ApplicationCache.GetMerchantDetails();
+        if (merchant == null)
+        {
+            return Result.Failure("Merchant details are not available.");
+        }
+
+        return await this.ReportsService.GetRecentActivityReceiptReport(merchant.MerchantReportingId,
+                                                                        request.ReportDate.Date,
+                                                                        request.SearchText,
+                                                                        request.PageNumber,
+                                                                        request.PageSize,
+                                                                        cancellationToken);
     }
 }

--- a/TransactionProcessor.Mobile.BusinessLogic/Requests/ReportQueries.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Requests/ReportQueries.cs
@@ -13,4 +13,9 @@ public record ReportQueries
                                                 TransactionMixBreakdown Breakdown,
                                                 TransactionMixMeasure Measure,
                                                 int TopN) : IRequest<Result<TransactionMixSummaryModel>>;
+
+    public record GetRecentActivityReceiptReportQuery(DateTime ReportDate,
+                                                      string? SearchText,
+                                                      int PageNumber = 1,
+                                                      int PageSize = 5) : IRequest<Result<RecentActivityReceiptReportModel>>;
 }

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/ReportsService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/ReportsService.cs
@@ -20,6 +20,16 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
                                                                           TransactionMixMeasure measure,
                                                                           int topN,
                                                                           CancellationToken cancellationToken);
+        Task<Result<RecentActivityReceiptReportModel>> GetRecentActivityReceiptReport(int merchantReportingId,
+                                                                                      DateTime reportDate,
+                                                                                      string? searchText,
+                                                                                      int pageNumber,
+                                                                                      int pageSize,
+                                                                                      CancellationToken cancellationToken);
+
+        Task<Result<RecentActivityReceiptResendResultModel>> ResendRecentActivityReceipt(string reference,
+                                                                                          string recipientEmailAddress,
+                                                                                          CancellationToken cancellationToken);
     }
     public class ReportsService : ClientProxyBase.ClientProxyBase, IReportsService
     {
@@ -135,6 +145,158 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
 
             return Result.Success(model);
         }
+
+        public async Task<Result<RecentActivityReceiptReportModel>> GetRecentActivityReceiptReport(int merchantReportingId,
+                                                                                                   DateTime reportDate,
+                                                                                                   string? searchText,
+                                                                                                   int pageNumber,
+                                                                                                   int pageSize,
+                                                                                                   CancellationToken cancellationToken)
+        {
+            TokenResponseModel accessToken = this.ApplicationCache.GetAccessToken();
+
+            String requestUri = this.BuildRequestUrl("/api/reporting/recentactivityreceiptsearch");
+
+            RecentActivityReceiptSearchRequest requestBody = new()
+            {
+                ApplicationVersion = this.ApplicationInfoService.VersionString,
+                MerchantReportingId = merchantReportingId,
+                ReportDate = reportDate.Date,
+                SearchText = string.IsNullOrWhiteSpace(searchText) ? null : searchText.Trim(),
+                PageNumber = pageNumber > 0 ? pageNumber : 1,
+                PageSize = pageSize > 0 ? pageSize : 5
+            };
+
+            Result<RecentActivityReceiptSearchResponseDto>? responseDataResult = await this.Post<RecentActivityReceiptSearchRequest, RecentActivityReceiptSearchResponseDto>(requestUri, requestBody, accessToken.AccessToken, cancellationToken);
+
+            if (responseDataResult.IsFailed)
+            {
+                Logger.LogInformation($"GetRecentActivityReceiptReport failed {responseDataResult.Status}");
+                return ResultHelpers.CreateFailure(responseDataResult);
+            }
+
+            RecentActivityReceiptReportModel model = new()
+            {
+                ReportDate = responseDataResult.Data.ReportDate,
+                SearchText = requestBody.SearchText,
+                PageNumber = responseDataResult.Data.PageNumber,
+                PageSize = responseDataResult.Data.PageSize,
+                TotalCount = responseDataResult.Data.TotalCount,
+                Items = responseDataResult.Data.Items.Select(item => new RecentActivityReceiptItemModel(item.Reference,
+                                                                                                      item.TransactionType,
+                                                                                                      item.Product,
+                                                                                                      item.Operator,
+                                                                                                      item.Status,
+                                                                                                      item.Amount,
+                                                                                                      item.TransactionDateTime,
+                                                                                                      item.ReceiptReference)).ToList()
+            };
+
+            return Result.Success(model);
+        }
+
+        public async Task<Result<RecentActivityReceiptResendResultModel>> ResendRecentActivityReceipt(string reference,
+                                                                                                      string recipientEmailAddress,
+                                                                                                      CancellationToken cancellationToken)
+        {
+            TokenResponseModel accessToken = this.ApplicationCache.GetAccessToken();
+
+            String requestUri = this.BuildRequestUrl($"/api/transactions/resendreceipt?applicationVersion={this.ApplicationInfoService.VersionString}");
+
+            ResendReceiptRequestMessage requestBody = new()
+            {
+                Reference = reference,
+                RecipientEmailAddress = recipientEmailAddress
+            };
+
+            Result<RecentActivityReceiptResendResponseDto>? responseDataResult = await this.Post<ResendReceiptRequestMessage, RecentActivityReceiptResendResponseDto>(requestUri, requestBody, accessToken.AccessToken, cancellationToken);
+
+            if (responseDataResult.IsFailed)
+            {
+                Logger.LogInformation($"ResendRecentActivityReceipt failed {responseDataResult.Status}");
+                return ResultHelpers.CreateFailure(responseDataResult);
+            }
+
+            RecentActivityReceiptResendResultModel model = new()
+            {
+                Success = responseDataResult.Data.Success,
+                Message = responseDataResult.Data.Message,
+                Reference = responseDataResult.Data.Reference,
+                ReceiptReference = responseDataResult.Data.ReceiptReference,
+                TransactionReference = responseDataResult.Data.TransactionReference
+            };
+
+            return model.Success
+                ? Result.Success(model)
+                : Result.Failure(model.Message ?? "Unable to resend the receipt.");
+        }
+    }
+
+    public class RecentActivityReceiptSearchRequest
+    {
+        public string ApplicationVersion { get; set; }
+
+        public int MerchantReportingId { get; set; }
+
+        public DateTime ReportDate { get; set; }
+
+        public string? SearchText { get; set; }
+
+        public int PageNumber { get; set; } = 1;
+
+        public int PageSize { get; set; } = 5;
+    }
+
+    public class RecentActivityReceiptSearchResponseDto
+    {
+        public DateTime ReportDate { get; set; }
+
+        public int PageNumber { get; set; }
+
+        public int PageSize { get; set; }
+
+        public int TotalCount { get; set; }
+
+        public List<RecentActivityReceiptSearchItemDto> Items { get; set; } = [];
+    }
+
+    public class RecentActivityReceiptSearchItemDto
+    {
+        public string Reference { get; set; }
+
+        public string TransactionType { get; set; }
+
+        public string Product { get; set; }
+
+        public string Operator { get; set; }
+
+        public string Status { get; set; }
+
+        public decimal Amount { get; set; }
+
+        public DateTime TransactionDateTime { get; set; }
+
+        public string ReceiptReference { get; set; }
+    }
+
+    public class RecentActivityReceiptResendResponseDto
+    {
+        public bool Success { get; set; }
+
+        public string Message { get; set; }
+
+        public string Reference { get; set; }
+
+        public string ReceiptReference { get; set; }
+
+        public string TransactionReference { get; set; }
+    }
+
+    public class ResendReceiptRequestMessage
+    {
+        public string Reference { get; set; }
+
+        public string RecipientEmailAddress { get; set; }
     }
 
     public class MerchantDailyPerformanceSummaryRequest

--- a/TransactionProcessor.Mobile.BusinessLogic/UIServices/IDialogService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/UIServices/IDialogService.cs
@@ -26,6 +26,12 @@ public interface IDialogService
                               TimeSpan? duration = null,
                               CancellationToken cancellationToken = default);
 
+    Task ShowSuccessToast(String message,
+                          Action? action = null,
+                          String? actionButtonText = "OK",
+                          TimeSpan? duration = null,
+                          CancellationToken cancellationToken = default);
+
     Task ShowWarningToast(String message,
                           Action? action = null,
                           String? actionButtonText = "OK",

--- a/TransactionProcessor.Mobile.BusinessLogic/UIServices/INavigationService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/UIServices/INavigationService.cs
@@ -1,11 +1,9 @@
-﻿using TransactionProcessor.Mobile.BusinessLogic.ViewModels.Transactions;
+using TransactionProcessor.Mobile.BusinessLogic.ViewModels.Transactions;
 
 namespace TransactionProcessor.Mobile.BusinessLogic.UIServices;
 
 public interface INavigationService
 {
-    #region Methods
-
     Task QuitApplication();
     Task GoBack();
 
@@ -14,7 +12,7 @@ public interface INavigationService
     Task GoToMobileTopupFailedPage();
 
     Task GoToMobileTopupPerformTopupPage(ProductDetails productDetails,
-                                             Decimal topupAmount);
+                                         Decimal topupAmount);
 
     Task GoToMobileTopupSelectOperatorPage();
 
@@ -43,7 +41,7 @@ public interface INavigationService
     Task GoToVoucherSelectProductPage(ProductDetails productDetails);
 
     Task GoToVoucherIssueVoucherPage(ProductDetails productDetails,
-                                         Decimal voucherAmount);
+                                     Decimal voucherAmount);
 
     Task GoToBillPaymentGetAccountPage(ProductDetails productDetails);
 
@@ -66,7 +64,9 @@ public interface INavigationService
 
     Task GoToTransactionMixSummaryPage();
 
-    Task GoToTransactions();
+    Task GoToRecentActivityReportPage();
 
-    #endregion
+    Task GoToRecentActivityReceiptDetailPage(TransactionProcessor.Mobile.BusinessLogic.Models.RecentActivityReceiptItemModel item);
+
+    Task GoToTransactions();
 }

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/RecentActivityReceiptDetailPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/RecentActivityReceiptDetailPageViewModel.cs
@@ -1,0 +1,151 @@
+using CommunityToolkit.Mvvm.Input;
+using TransactionProcessor.Mobile.BusinessLogic.Common;
+using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Services;
+using TransactionProcessor.Mobile.BusinessLogic.UIServices;
+using SimpleResults;
+
+namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports;
+
+public sealed partial class RecentActivityReceiptDetailPageViewModel : ExtendedBaseViewModel
+{
+    private RecentActivityReceiptItemModel? selectedItem;
+    private string? emailAddress;
+    private bool isResendingReceipt;
+    private readonly IReportsService reportsService;
+
+    public RecentActivityReceiptDetailPageViewModel(INavigationService navigationService,
+                                                    IApplicationCache applicationCache,
+                                                    IDialogService dialogService,
+                                                    IDeviceService deviceService,
+                                                    INavigationParameterService navigationParameterService,
+                                                    IReportsService reportsService) : base(applicationCache, dialogService, navigationService, deviceService, navigationParameterService)
+    {
+        this.Title = "Receipt Detail";
+        this.reportsService = reportsService;
+    }
+
+    public RecentActivityReceiptItemModel? SelectedItem
+    {
+        get => this.selectedItem;
+        private set
+        {
+            if (SetProperty(ref this.selectedItem, value))
+            {
+                this.OnPropertyChanged(nameof(this.Reference));
+                this.OnPropertyChanged(nameof(this.TransactionType));
+                this.OnPropertyChanged(nameof(this.Product));
+                this.OnPropertyChanged(nameof(this.Operator));
+                this.OnPropertyChanged(nameof(this.Status));
+                this.OnPropertyChanged(nameof(this.Amount));
+                this.OnPropertyChanged(nameof(this.TransactionDateTime));
+                this.OnPropertyChanged(nameof(this.ReceiptReference));
+                this.OnPropertyChanged(nameof(this.HasReceipt));
+                this.ResendReceiptCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public string? EmailAddress
+    {
+        get => this.emailAddress;
+        set
+        {
+            if (SetProperty(ref this.emailAddress, value))
+            {
+                this.ResendReceiptCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public bool IsResendingReceipt
+    {
+        get => this.isResendingReceipt;
+        private set
+        {
+            if (SetProperty(ref this.isResendingReceipt, value))
+            {
+                this.ResendReceiptCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public string Reference => this.SelectedItem?.Reference ?? string.Empty;
+
+    public string TransactionType => this.SelectedItem?.TransactionType ?? string.Empty;
+
+    public string Product => this.SelectedItem?.Product ?? string.Empty;
+
+    public string Operator => this.SelectedItem?.Operator ?? string.Empty;
+
+    public string Status => this.SelectedItem?.Status ?? string.Empty;
+
+    public string Amount => this.SelectedItem is null ? string.Empty : this.SelectedItem.Amount.ToString("N2");
+
+    public string TransactionDateTime => this.SelectedItem is null ? string.Empty : this.SelectedItem.TransactionDateTime.ToString("dd MMM yyyy HH:mm");
+
+    public string ReceiptReference => this.SelectedItem?.ReceiptReference ?? string.Empty;
+
+    public bool HasReceipt => this.SelectedItem is not null;
+
+    [RelayCommand(CanExecute = nameof(CanResendReceipt))]
+    private async Task ResendReceipt()
+    {
+        if (this.CanResendReceipt() == false || this.IsValidEmailAddress(this.EmailAddress) == false)
+        {
+            await this.DialogService.ShowWarningToast("Enter a valid email address before resending the receipt.");
+            return;
+        }
+
+        this.IsResendingReceipt = true;
+        try
+        {
+            string recipientEmailAddress = this.EmailAddress!.Trim();
+            Result<RecentActivityReceiptResendResultModel> result = await this.reportsService.ResendRecentActivityReceipt(this.Reference,
+                                                                                                                           recipientEmailAddress,
+                                                                                                                           CancellationToken.None);
+
+            if (result.IsFailed)
+            {
+                await this.DialogService.ShowWarningToast(result.Message ?? "Unable to resend the receipt.");
+                return;
+            }
+
+            string message = string.IsNullOrWhiteSpace(result.Data.Message)
+                ? $"Receipt sent to {recipientEmailAddress}."
+                : $"{result.Data.Message} Sent to {recipientEmailAddress}.";
+
+            this.EmailAddress = string.Empty;
+            await this.DialogService.ShowSuccessToast(message);
+        }
+        finally
+        {
+            this.IsResendingReceipt = false;
+        }
+    }
+
+    private bool CanResendReceipt()
+    {
+        return this.HasReceipt
+            && this.IsResendingReceipt == false
+            && string.IsNullOrWhiteSpace(this.EmailAddress) == false;
+    }
+
+    private bool IsValidEmailAddress(string? emailAddress)
+    {
+        return string.IsNullOrWhiteSpace(emailAddress) == false
+            && emailAddress.Contains('@', StringComparison.OrdinalIgnoreCase)
+            && emailAddress.Contains('.', StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override async Task Initialise(CancellationToken cancellationToken)
+    {
+        await base.Initialise(cancellationToken);
+
+        IDictionary<string, object> parameters = this.NavigationParameterService.GetParameters();
+        if (parameters.TryGetValue(nameof(RecentActivityReceiptItemModel), out object? item) && item is RecentActivityReceiptItemModel selectedItem)
+        {
+            this.SelectedItem = selectedItem;
+        }
+    }
+}

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/RecentActivityReportPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/RecentActivityReportPageViewModel.cs
@@ -1,0 +1,189 @@
+using CommunityToolkit.Mvvm.Input;
+using MediatR;
+using SimpleResults;
+using TransactionProcessor.Mobile.BusinessLogic.Common;
+using TransactionProcessor.Mobile.BusinessLogic.Models;
+using TransactionProcessor.Mobile.BusinessLogic.Requests;
+using TransactionProcessor.Mobile.BusinessLogic.Services;
+using TransactionProcessor.Mobile.BusinessLogic.UIServices;
+
+namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports;
+
+public sealed partial class RecentActivityReportPageViewModel : ExtendedBaseViewModel
+{
+    private const int DefaultPageSize = 5;
+    private readonly IMediator Mediator;
+    private DateTime selectedDate;
+    private string? searchText;
+    private bool isLoading;
+    private string? errorMessage;
+    private RecentActivityReceiptReportModel? report;
+    private int pageNumber = 1;
+
+    public RecentActivityReportPageViewModel(IMediator mediator,
+                                             INavigationService navigationService,
+                                             IApplicationCache applicationCache,
+                                             IDialogService dialogService,
+                                             IDeviceService deviceService,
+                                             INavigationParameterService navigationParameterService) : base(applicationCache, dialogService, navigationService, deviceService, navigationParameterService)
+    {
+        this.Mediator = mediator;
+        this.Title = "Recent Activity and Receipt Report";
+        this.SelectedDate = DateTime.Today;
+    }
+
+    public DateTime SelectedDate
+    {
+        get => this.selectedDate;
+        set => SetProperty(ref this.selectedDate, value);
+    }
+
+    public string? SearchText
+    {
+        get => this.searchText;
+        set => SetProperty(ref this.searchText, value);
+    }
+
+    public bool IsLoading
+    {
+        get => this.isLoading;
+        set => SetProperty(ref this.isLoading, value);
+    }
+
+    public string? ErrorMessage
+    {
+        get => this.errorMessage;
+        set => SetProperty(ref this.errorMessage, value);
+    }
+
+    public RecentActivityReceiptReportModel? Report
+    {
+        get => this.report;
+        private set => SetProperty(ref this.report, value);
+    }
+
+    public int PageNumber
+    {
+        get => this.pageNumber;
+        private set
+        {
+            if (SetProperty(ref this.pageNumber, value))
+            {
+                this.OnPropertyChanged(nameof(this.PageDisplayText));
+                this.OnPropertyChanged(nameof(this.CanGoToPreviousPage));
+                this.OnPropertyChanged(nameof(this.CanGoToNextPage));
+                this.OnPropertyChanged(nameof(this.HasPagination));
+                this.PreviousPageCommand.NotifyCanExecuteChanged();
+                this.NextPageCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public int PageSize => DefaultPageSize;
+
+    public IReadOnlyList<RecentActivityReceiptItemModel> Items => this.Report?.Items ?? [];
+
+    public bool HasResults => this.Items.Count > 0;
+
+    public bool HasError => string.IsNullOrWhiteSpace(this.ErrorMessage) == false;
+
+    public bool HasEmptyState => this.IsLoading == false && this.HasError == false && this.HasResults == false;
+
+    public int TotalCount => this.Report?.TotalCount ?? 0;
+
+    public int TotalPages => this.Report?.TotalPages ?? 0;
+
+    public bool CanGoToPreviousPage => this.PageNumber > 1;
+
+    public bool CanGoToNextPage => this.TotalPages > 0 && this.PageNumber < this.TotalPages;
+
+    public bool HasPagination => this.TotalPages > 1;
+
+    public string PageDisplayText => this.TotalPages <= 0
+        ? string.Empty
+        : $"Page {this.PageNumber} of {this.TotalPages}";
+
+    public override async Task Initialise(CancellationToken cancellationToken)
+    {
+        await base.Initialise(cancellationToken);
+        await this.LoadReportAsync(1, cancellationToken);
+    }
+
+    [RelayCommand]
+    private async Task Search()
+    {
+        await this.LoadReportAsync(1, CancellationToken.None);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanGoToPreviousPage))]
+    private async Task PreviousPage()
+    {
+        await this.LoadReportAsync(this.PageNumber - 1, CancellationToken.None);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanGoToNextPage))]
+    private async Task NextPage()
+    {
+        await this.LoadReportAsync(this.PageNumber + 1, CancellationToken.None);
+    }
+
+    [RelayCommand]
+    private async Task OpenItem(RecentActivityReceiptItemModel item)
+    {
+        await this.NavigationService.GoToRecentActivityReceiptDetailPage(item);
+    }
+
+    private async Task LoadReportAsync(int pageNumber, CancellationToken cancellationToken)
+    {
+        this.IsLoading = true;
+        this.ErrorMessage = null;
+
+        try
+        {
+            int requestedPageNumber = pageNumber > 0 ? pageNumber : 1;
+            Result<RecentActivityReceiptReportModel> result = await this.Mediator.Send(new ReportQueries.GetRecentActivityReceiptReportQuery(
+                                                                                              this.SelectedDate.Date,
+                                                                                              string.IsNullOrWhiteSpace(this.SearchText) ? null : this.SearchText.Trim(),
+                                                                                              requestedPageNumber,
+                                                                                              DefaultPageSize),
+                                                                                          cancellationToken);
+            if (result.IsFailed)
+            {
+                this.Report = null;
+                this.ErrorMessage = "Unable to load recent activity.";
+                return;
+            }
+
+            this.Report = result.Data;
+            this.PageNumber = result.Data.PageNumber > 0 ? result.Data.PageNumber : requestedPageNumber;
+            this.OnPropertyChanged(nameof(this.Items));
+            this.OnPropertyChanged(nameof(this.HasResults));
+            this.OnPropertyChanged(nameof(this.HasEmptyState));
+            this.OnPropertyChanged(nameof(this.TotalCount));
+            this.OnPropertyChanged(nameof(this.TotalPages));
+            this.OnPropertyChanged(nameof(this.PageDisplayText));
+            this.OnPropertyChanged(nameof(this.CanGoToPreviousPage));
+            this.OnPropertyChanged(nameof(this.CanGoToNextPage));
+            this.OnPropertyChanged(nameof(this.HasPagination));
+        }
+        catch
+        {
+            this.Report = null;
+            this.ErrorMessage = "Unable to load recent activity.";
+        }
+        finally
+        {
+            this.IsLoading = false;
+            this.OnPropertyChanged(nameof(this.Items));
+            this.OnPropertyChanged(nameof(this.HasResults));
+            this.OnPropertyChanged(nameof(this.HasError));
+            this.OnPropertyChanged(nameof(this.HasEmptyState));
+            this.OnPropertyChanged(nameof(this.TotalCount));
+            this.OnPropertyChanged(nameof(this.TotalPages));
+            this.OnPropertyChanged(nameof(this.PageDisplayText));
+            this.OnPropertyChanged(nameof(this.CanGoToPreviousPage));
+            this.OnPropertyChanged(nameof(this.CanGoToNextPage));
+            this.OnPropertyChanged(nameof(this.HasPagination));
+        }
+    }
+}

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/ReportsPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/ReportsPageViewModel.cs
@@ -50,7 +50,10 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports
                                                                  new ListViewItem {
                                                                                       Title = "Transaction Mix"
                                                                                   },
-                                                              };
+                                                                 new ListViewItem {
+                                                                                      Title = "Recent Activity and Receipt Report"
+                                                                                  },
+                                                               };
             await base.Initialise(cancellationToken);
         }
 
@@ -64,6 +67,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports
             {
                 ReportsOptions.DailyPerformanceSummary => this.NavigationService.GoToDailyPerformanceSummaryPage(),
                 ReportsOptions.TransactionMix => this.NavigationService.GoToTransactionMixSummaryPage(),
+                ReportsOptions.RecentActivityAndReceiptReport => this.NavigationService.GoToRecentActivityReportPage(),
                 _ => Task.Factory.StartNew(() => Logger.LogWarning($"Unsupported option selected {selectedOption}"))
             };
 
@@ -79,6 +83,8 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports
             DailyPerformanceSummary = 0,
 
             TransactionMix = 1,
+
+            RecentActivityAndReceiptReport = 2,
         }
 
         #endregion

--- a/TransactionProcessor.Mobile.UITests/Pages/RecentActivityReceiptDetailPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/RecentActivityReceiptDetailPage.cs
@@ -1,0 +1,12 @@
+using TransactionProcessor.Mobile.UITests.Common;
+
+namespace TransactionProcessor.Mobile.UITests.Pages;
+
+public class RecentActivityReceiptDetailPage : BasePage2
+{
+    protected override string Trait => "RecentActivityReceiptDetail";
+
+    public RecentActivityReceiptDetailPage(TestingContext testingContext) : base(testingContext)
+    {
+    }
+}

--- a/TransactionProcessor.Mobile.UITests/Pages/RecentActivityReportPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/RecentActivityReportPage.cs
@@ -1,0 +1,32 @@
+using OpenQA.Selenium;
+using TransactionProcessor.Mobile.UITests.Common;
+
+namespace TransactionProcessor.Mobile.UITests.Pages;
+
+public class RecentActivityReportPage : BasePage2
+{
+    protected override string Trait => "RecentActivityReport";
+
+    public RecentActivityReportPage(TestingContext testingContext) : base(testingContext)
+    {
+    }
+
+    public async Task EnterSearchText(string searchText)
+    {
+        IWebElement element = await this.WaitForElementByAccessibilityId("RecentActivitySearchText");
+        element.Clear();
+        element.SendKeys(searchText);
+    }
+
+    public async Task ClickSearchButton()
+    {
+        IWebElement element = await this.WaitForElementByAccessibilityId("RecentActivitySearchButton");
+        element.Click();
+    }
+
+    public async Task ClickResult(string reference)
+    {
+        IWebElement element = await this.WaitForElementByAccessibilityId(reference);
+        element.Click();
+    }
+}

--- a/TransactionProcessor.Mobile.UITests/Pages/ReportsPage.cs
+++ b/TransactionProcessor.Mobile.UITests/Pages/ReportsPage.cs
@@ -20,6 +20,7 @@ public class ReportsPage : BasePage2
 
     private readonly String DailyPerformanceSummaryButton;
     private readonly String TransactionMixButton;
+    private readonly String RecentActivityAndReceiptReportButton;
     
 
 
@@ -27,6 +28,7 @@ public class ReportsPage : BasePage2
     {
         this.DailyPerformanceSummaryButton = "DailyPerformanceSummaryButton";
         this.TransactionMixButton = "TransactionMixButton";
+        this.RecentActivityAndReceiptReportButton = "RecentActivityAndReceiptReportButton";
     }
 
     public async Task ClickDailyPerformanceSummaryButton()
@@ -38,6 +40,12 @@ public class ReportsPage : BasePage2
     public async Task ClickTransactionMixButton()
     {
         IWebElement element = await this.WaitForElementByAccessibilityId(this.TransactionMixButton);
+        element.Click();
+    }
+
+    public async Task ClickRecentActivityAndReceiptReportButton()
+    {
+        IWebElement element = await this.WaitForElementByAccessibilityId(this.RecentActivityAndReceiptReportButton);
         element.Click();
     }
 

--- a/TransactionProcessor.Mobile.UITests/Steps/ReportsSteps.cs
+++ b/TransactionProcessor.Mobile.UITests/Steps/ReportsSteps.cs
@@ -9,11 +9,19 @@ public class ReportsSteps{
     private readonly ReportsPage ReportsPage;
     private readonly DailyPerformanceSummaryPage DailyPerformanceSummaryPage;
     private readonly TransactionMixPage TransactionMixPage;
+    private readonly RecentActivityReportPage RecentActivityReportPage;
+    private readonly RecentActivityReceiptDetailPage RecentActivityReceiptDetailPage;
 
-    public ReportsSteps(ReportsPage reportsPage, DailyPerformanceSummaryPage dailyPerformanceSummaryPage, TransactionMixPage transactionMixPage){
+    public ReportsSteps(ReportsPage reportsPage,
+                        DailyPerformanceSummaryPage dailyPerformanceSummaryPage,
+                        TransactionMixPage transactionMixPage,
+                        RecentActivityReportPage recentActivityReportPage,
+                        RecentActivityReceiptDetailPage recentActivityReceiptDetailPage){
         this.ReportsPage = reportsPage;
         this.DailyPerformanceSummaryPage = dailyPerformanceSummaryPage;
         this.TransactionMixPage = transactionMixPage;
+        this.RecentActivityReportPage = recentActivityReportPage;
+        this.RecentActivityReceiptDetailPage = recentActivityReceiptDetailPage;
     }
 
     [Then(@"the Reports Page is displayed")]
@@ -34,6 +42,12 @@ public class ReportsSteps{
         await this.ReportsPage.ClickTransactionMixButton();
     }
 
+    [When(@"I tap on the Recent Activity and Receipt Report Button")]
+    public async Task WhenITapOnTheRecentActivityAndReceiptReportButton()
+    {
+        await this.ReportsPage.ClickRecentActivityAndReceiptReportButton();
+    }
+
     [Then(@"the Daily Performance Summary Report is displayed")]
     public async Task ThenTheDailyPerformanceSummaryReportIsDisplayed()
     {
@@ -45,6 +59,30 @@ public class ReportsSteps{
     {
         await this.TransactionMixPage.AssertOnPage();
         await this.TransactionMixPage.AssertSummaryVisible();
+    }
+
+    [Then(@"the Recent Activity Report is displayed")]
+    public async Task ThenTheRecentActivityReportIsDisplayed()
+    {
+        await this.RecentActivityReportPage.AssertOnPage();
+    }
+
+    [When(@"I tap on Search on the Recent Activity Report")]
+    public async Task WhenITapOnSearchOnTheRecentActivityReport()
+    {
+        await this.RecentActivityReportPage.ClickSearchButton();
+    }
+
+    [When(@"I tap on the Recent Activity result for '(.*)'")]
+    public async Task WhenITapOnTheRecentActivityResultFor(string reference)
+    {
+        await this.RecentActivityReportPage.ClickResult(reference);
+    }
+
+    [Then(@"the Recent Activity Receipt Detail Page is displayed")]
+    public async Task ThenTheRecentActivityReceiptDetailPageIsDisplayed()
+    {
+        await this.RecentActivityReceiptDetailPage.AssertOnPage();
     }
 
     [Then(@"the Transaction Mix Chart is displayed")]

--- a/TransactionProcessor.Mobile/App.xaml.cs
+++ b/TransactionProcessor.Mobile/App.xaml.cs
@@ -179,6 +179,8 @@ namespace TransactionProcessor.Mobile
 
             RegisterRouteOnce(nameof(DailyPerformanceSummaryPage), typeof(DailyPerformanceSummaryPage));
             RegisterRouteOnce(nameof(TransactionMixPage), typeof(TransactionMixPage));
+            RegisterRouteOnce(nameof(RecentActivityReportPage), typeof(RecentActivityReportPage));
+            RegisterRouteOnce(nameof(RecentActivityReceiptDetailPage), typeof(RecentActivityReceiptDetailPage));
 
             RegisterRouteOnce(nameof(MyAccountAddressesPage), typeof(MyAccountAddressesPage));
             RegisterRouteOnce(nameof(MyAccountContactPage), typeof(MyAccountContactPage));

--- a/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
+++ b/TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs
@@ -229,6 +229,8 @@ namespace TransactionProcessor.Mobile.Extensions {
             builder.Services.AddTransient<ReportsPageViewModel>();
             builder.Services.AddTransient<DailyPerformanceSummaryPageViewModel>();
             builder.Services.AddTransient<TransactionMixPageViewModel>();
+            builder.Services.AddTransient<RecentActivityReportPageViewModel>();
+            builder.Services.AddTransient<RecentActivityReceiptDetailPageViewModel>();
 
             return builder;
         }
@@ -271,6 +273,8 @@ namespace TransactionProcessor.Mobile.Extensions {
             builder.Services.AddTransient<ReportsPage>();
             builder.Services.AddTransient<DailyPerformanceSummaryPage>();
             builder.Services.AddTransient<TransactionMixPage>();
+            builder.Services.AddTransient<RecentActivityReportPage>();
+            builder.Services.AddTransient<RecentActivityReceiptDetailPage>();
             
             return builder;
         }

--- a/TransactionProcessor.Mobile/Pages/Reports/RecentActivityReceiptDetailPage.xaml
+++ b/TransactionProcessor.Mobile/Pages/Reports/RecentActivityReceiptDetailPage.xaml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:TransactionProcessor.Mobile.Controls"
+             xmlns:reports="clr-namespace:TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports;assembly=TransactionProcessor.Mobile.BusinessLogic"
+             x:Class="TransactionProcessor.Mobile.Pages.Reports.RecentActivityReceiptDetailPage"
+             x:Name="RecentActivityReceiptDetailPageRoot"
+             x:DataType="reports:RecentActivityReceiptDetailPageViewModel"
+             Shell.NavBarIsVisible="False">
+
+    <ScrollView>
+        <VerticalStackLayout Style="{DynamicResource Layout}" Spacing="18">
+            <controls:TitleLabel Text="{Binding Title}"
+                                 AutomationId="RecentActivityReceiptDetail"
+                                 FontSize="20"
+                                 HorizontalTextAlignment="Center"
+                                 VerticalOptions="End"
+                                 FontAttributes="Bold"
+                                 TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}"
+                                 Padding="20,0,20,8" />
+
+            <Frame Style="{StaticResource TransactionFormCard}"
+                   BackgroundColor="{DynamicResource salesAnalysisCardBackgroundColor}"
+                   BorderColor="{DynamicResource salesAnalysisCardBorderColor}"
+                   Padding="14"
+                   CornerRadius="14"
+                   HasShadow="False"
+                   Margin="0">
+                <Grid ColumnDefinitions="*,Auto"
+                      RowDefinitions="Auto,Auto,Auto,Auto"
+                      ColumnSpacing="12"
+                      RowSpacing="8">
+                    <Label Text="{Binding Reference}"
+                           FontSize="18"
+                           FontAttributes="Bold"
+                           TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                    <Frame Grid.Column="1"
+                           Padding="10,4"
+                           CornerRadius="999"
+                           HasShadow="False"
+                           HorizontalOptions="End"
+                           VerticalOptions="Start"
+                           BackgroundColor="#EAF7EE"
+                           BorderColor="#1E8E3E">
+                        <Frame.Triggers>
+                            <DataTrigger TargetType="Frame"
+                                         Binding="{Binding Status}"
+                                         Value="Failed">
+                                <Setter Property="BackgroundColor" Value="#FDEEEF" />
+                                <Setter Property="BorderColor" Value="#D64545" />
+                            </DataTrigger>
+                        </Frame.Triggers>
+                        <Label Text="{Binding Status}"
+                               FontSize="11"
+                               FontAttributes="Bold"
+                               HorizontalTextAlignment="Center"
+                               VerticalTextAlignment="Center"
+                               TextColor="#1E8E3E">
+                            <Label.Triggers>
+                                <DataTrigger TargetType="Label"
+                                             Binding="{Binding Status}"
+                                             Value="Failed">
+                                    <Setter Property="TextColor" Value="#D64545" />
+                                </DataTrigger>
+                            </Label.Triggers>
+                        </Label>
+                    </Frame>
+                    <Label Grid.Row="1"
+                           Text="{Binding ReceiptReference, StringFormat='Receipt: {0}'}"
+                           FontSize="12"
+                           TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                    <Label Grid.Row="1"
+                           Grid.Column="1"
+                           Text="{Binding Amount, StringFormat='{0:N2}'}"
+                           FontSize="16"
+                           FontAttributes="Bold"
+                           HorizontalTextAlignment="End"
+                           TextColor="#1E8E3E">
+                        <Label.Triggers>
+                            <DataTrigger TargetType="Label"
+                                         Binding="{Binding Status}"
+                                         Value="Failed">
+                                <Setter Property="TextColor" Value="#D64545" />
+                            </DataTrigger>
+                        </Label.Triggers>
+                    </Label>
+                    <Label Grid.Row="2"
+                           Text="{Binding TransactionType, StringFormat='Transaction type: {0}'}"
+                           FontSize="12"
+                           TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                    <Label Grid.Row="2"
+                           Grid.Column="1"
+                           Text="{Binding TransactionDateTime, StringFormat='Date/time: {0}'}"
+                           FontSize="12"
+                           HorizontalTextAlignment="End"
+                           TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                    <Label Grid.Row="3"
+                           Text="{Binding Product, StringFormat='Product: {0}'}"
+                           FontSize="12"
+                           TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                    <Label Grid.Row="3"
+                           Grid.Column="1"
+                           Text="{Binding Operator, StringFormat='Operator: {0}'}"
+                           FontSize="12"
+                           HorizontalTextAlignment="End"
+                           TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                </Grid>
+            </Frame>
+
+            <Frame Style="{StaticResource TransactionFormCard}"
+                   BackgroundColor="{DynamicResource salesAnalysisCardBackgroundColor}"
+                   BorderColor="{DynamicResource salesAnalysisCardBorderColor}"
+                   Padding="14"
+                   CornerRadius="14"
+                   HasShadow="False"
+                   Margin="0">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Resend receipt"
+                           FontSize="16"
+                           FontAttributes="Bold"
+                           TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                    <Entry Text="{Binding EmailAddress}"
+                           Placeholder="Enter email address"
+                           Keyboard="Email"
+                           AutomationId="RecentActivityReceiptEmailAddress"
+                           TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                    <Button Text="Resend receipt"
+                            AutomationId="RecentActivityReceiptResendButton"
+                            Style="{StaticResource ReportsButtonStyle}"
+                            Command="{Binding ResendReceiptCommand}" />
+                    <ActivityIndicator IsRunning="{Binding IsResendingReceipt}"
+                                       IsVisible="{Binding IsResendingReceipt}"
+                                       Color="{StaticResource reports}"
+                                       HorizontalOptions="Center" />
+                </VerticalStackLayout>
+            </Frame>
+
+            <Button Text="Back"
+                    AutomationId="BackButton"
+                    Style="{StaticResource ReportsButtonStyle}"
+                    Command="{Binding BackButtonCommand}" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/TransactionProcessor.Mobile/Pages/Reports/RecentActivityReceiptDetailPage.xaml.cs
+++ b/TransactionProcessor.Mobile/Pages/Reports/RecentActivityReceiptDetailPage.xaml.cs
@@ -1,0 +1,20 @@
+using TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports;
+
+namespace TransactionProcessor.Mobile.Pages.Reports;
+
+public partial class RecentActivityReceiptDetailPage : ContentPage
+{
+    private RecentActivityReceiptDetailPageViewModel viewModel => this.BindingContext as RecentActivityReceiptDetailPageViewModel;
+
+    public RecentActivityReceiptDetailPage(RecentActivityReceiptDetailPageViewModel vm)
+    {
+        this.InitializeComponent();
+        this.BindingContext = vm;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await this.viewModel.Initialise(CancellationToken.None);
+    }
+}

--- a/TransactionProcessor.Mobile/Pages/Reports/RecentActivityReportPage.xaml
+++ b/TransactionProcessor.Mobile/Pages/Reports/RecentActivityReportPage.xaml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:TransactionProcessor.Mobile.Controls"
+             xmlns:models="clr-namespace:TransactionProcessor.Mobile.BusinessLogic.Models;assembly=TransactionProcessor.Mobile.BusinessLogic"
+             xmlns:reports="clr-namespace:TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports;assembly=TransactionProcessor.Mobile.BusinessLogic"
+             x:Class="TransactionProcessor.Mobile.Pages.Reports.RecentActivityReportPage"
+             x:Name="RecentActivityReportPageRoot"
+             x:DataType="reports:RecentActivityReportPageViewModel"
+             Shell.NavBarIsVisible="False">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="RecentActivityItemTemplate" x:DataType="models:RecentActivityReceiptItemModel">
+                <Frame Style="{StaticResource TransactionFormCard}"
+                       Padding="14"
+                       BackgroundColor="{DynamicResource salesAnalysisCardBackgroundColor}"
+                       BorderColor="{DynamicResource salesAnalysisCardBorderColor}"
+                       CornerRadius="14"
+                       HasShadow="False"
+                       Margin="0"
+                       AutomationId="{Binding Reference}">
+                    <Frame.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding BindingContext.OpenItemCommand, Source={x:Reference RecentActivityReportPageRoot}}"
+                                              CommandParameter="{Binding .}" />
+                    </Frame.GestureRecognizers>
+                    <Grid ColumnDefinitions="*,Auto"
+                          RowDefinitions="Auto,Auto,Auto"
+                          ColumnSpacing="12"
+                          RowSpacing="4">
+                        <Label Text="{Binding Reference}"
+                               FontAttributes="Bold"
+                               FontSize="14"
+                               TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                        <Frame Grid.Column="1"
+                               Padding="10,4"
+                               CornerRadius="999"
+                               HasShadow="False"
+                               HorizontalOptions="End"
+                               VerticalOptions="Start"
+                               BackgroundColor="#EAF7EE"
+                               BorderColor="#1E8E3E">
+                            <Frame.Triggers>
+                                <DataTrigger TargetType="Frame"
+                                             Binding="{Binding Status}"
+                                             Value="Failed">
+                                    <Setter Property="BackgroundColor" Value="#FDEEEF" />
+                                    <Setter Property="BorderColor" Value="#D64545" />
+                                </DataTrigger>
+                            </Frame.Triggers>
+                            <Label Text="{Binding Status}"
+                                   FontSize="11"
+                                   FontAttributes="Bold"
+                                   HorizontalTextAlignment="Center"
+                                   VerticalTextAlignment="Center"
+                                   TextColor="#1E8E3E">
+                                <Label.Triggers>
+                                    <DataTrigger TargetType="Label"
+                                                 Binding="{Binding Status}"
+                                                 Value="Failed">
+                                        <Setter Property="TextColor" Value="#D64545" />
+                                    </DataTrigger>
+                                </Label.Triggers>
+                            </Label>
+                        </Frame>
+                        <Label Grid.Row="1"
+                               Text="{Binding Product}"
+                               FontSize="12"
+                               Opacity="0.85"
+                               TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                        <Label Grid.Row="1"
+                               Grid.Column="1"
+                               Text="{Binding Amount, StringFormat='{0:N2}'}"
+                               FontSize="14"
+                               FontAttributes="Bold"
+                               HorizontalTextAlignment="End"
+                               TextColor="#1E8E3E">
+                            <Label.Triggers>
+                                <DataTrigger TargetType="Label"
+                                             Binding="{Binding Status}"
+                                             Value="Failed">
+                                    <Setter Property="TextColor" Value="#D64545" />
+                                </DataTrigger>
+                            </Label.Triggers>
+                        </Label>
+                        <Label Grid.Row="2"
+                               Text="{Binding Operator}"
+                               FontSize="11"
+                               Opacity="0.75"
+                               TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                        <Label Grid.Row="2"
+                               Grid.Column="1"
+                               Text="{Binding TransactionDateTime, StringFormat='{0:dd MMM HH:mm}'}"
+                               FontSize="11"
+                               Opacity="0.75"
+                               HorizontalTextAlignment="End"
+                               TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                    </Grid>
+                </Frame>
+            </DataTemplate>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <Grid Style="{DynamicResource Layout}"
+          RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto"
+          RowSpacing="18">
+            <controls:TitleLabel Text="{Binding Title}"
+                                 AutomationId="RecentActivityReport"
+                                 Grid.Row="0"
+                                 FontSize="20"
+                                 HorizontalTextAlignment="Center"
+                                 VerticalOptions="End"
+                                 FontAttributes="Bold"
+                                 TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}"
+                                 Padding="20,0,20,8" />
+
+            <Label Text="Single date only"
+                   Grid.Row="1"
+                   FontSize="12"
+                   Opacity="0.8"
+                   TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+
+            <DatePicker Date="{Binding SelectedDate}"
+                        Grid.Row="2"
+                        Format="dd MMM yyyy"
+                        AutomationId="RecentActivityDatePicker"
+                        TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+
+            <Entry Text="{Binding SearchText}"
+                   Grid.Row="3"
+                   Placeholder="Search transaction ID, receipt, status, product or operator"
+                   AutomationId="RecentActivitySearchText"
+                   TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+
+            <Button Text="Search"
+                    Grid.Row="4"
+                    AutomationId="RecentActivitySearchButton"
+                    Style="{StaticResource ReportsButtonStyle}"
+                    Command="{Binding SearchCommand}" />
+
+            <ActivityIndicator IsRunning="{Binding IsLoading}"
+                               Grid.Row="5"
+                               IsVisible="{Binding IsLoading}"
+                               Color="{StaticResource reports}"
+                               HorizontalOptions="Center" />
+
+            <VerticalStackLayout Grid.Row="6"
+                                 IsVisible="{Binding HasError}"
+                                 Spacing="4">
+                <Label Text="Unable to load recent activity."
+                       FontAttributes="Bold"
+                       TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                <Label Text="{Binding ErrorMessage}"
+                       FontSize="12"
+                       Opacity="0.8"
+                       TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+            </VerticalStackLayout>
+
+            <Grid Grid.Row="7"
+                  RowDefinitions="Auto,*,Auto"
+                  RowSpacing="12"
+                  IsVisible="{Binding HasResults}">
+                <Label Text="Results"
+                       Grid.Row="0"
+                       FontSize="16"
+                       FontAttributes="Bold"
+                       TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+
+                <CollectionView Grid.Row="1"
+                                ItemsSource="{Binding Items}"
+                                ItemTemplate="{StaticResource RecentActivityItemTemplate}"
+                                SelectionMode="None"
+                                AutomationId="RecentActivityResults">
+                    <CollectionView.ItemsLayout>
+                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
+                    </CollectionView.ItemsLayout>
+                </CollectionView>
+
+                <HorizontalStackLayout Grid.Row="2"
+                                       Spacing="12"
+                                       HorizontalOptions="Center"
+                                       IsVisible="{Binding HasPagination}">
+                    <Button Text="Previous"
+                            Style="{StaticResource ReportsButtonStyle}"
+                            Command="{Binding PreviousPageCommand}"
+                            IsEnabled="{Binding CanGoToPreviousPage}" />
+                    <Label Text="{Binding PageDisplayText}"
+                           VerticalTextAlignment="Center"
+                           FontAttributes="Bold"
+                           TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                    <Button Text="Next"
+                            Style="{StaticResource ReportsButtonStyle}"
+                            Command="{Binding NextPageCommand}"
+                            IsEnabled="{Binding CanGoToNextPage}" />
+                </HorizontalStackLayout>
+            </Grid>
+
+            <VerticalStackLayout Grid.Row="7"
+                                 IsVisible="{Binding HasEmptyState}"
+                                 Spacing="4">
+                <Label Text="No recent activity found."
+                       FontAttributes="Bold"
+                       TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+                <Label Text="Try another search term for the same date."
+                       FontSize="12"
+                       Opacity="0.8"
+                       TextColor="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
+            </VerticalStackLayout>
+
+            <Button Text="Back"
+                    Grid.Row="8"
+                    AutomationId="BackButton"
+                    Style="{StaticResource ReportsButtonStyle}"
+                    Command="{Binding BackButtonCommand}" />
+    </Grid>
+</ContentPage>

--- a/TransactionProcessor.Mobile/Pages/Reports/RecentActivityReportPage.xaml.cs
+++ b/TransactionProcessor.Mobile/Pages/Reports/RecentActivityReportPage.xaml.cs
@@ -1,0 +1,28 @@
+using TransactionProcessor.Mobile.BusinessLogic.ViewModels.Reports;
+
+namespace TransactionProcessor.Mobile.Pages.Reports;
+
+public partial class RecentActivityReportPage : ContentPage
+{
+    private RecentActivityReportPageViewModel viewModel => this.BindingContext as RecentActivityReportPageViewModel;
+    private bool hasInitialised;
+
+    public RecentActivityReportPage(RecentActivityReportPageViewModel vm)
+    {
+        this.InitializeComponent();
+        this.BindingContext = vm;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+
+        if (this.hasInitialised)
+        {
+            return;
+        }
+
+        this.hasInitialised = true;
+        await this.viewModel.Initialise(CancellationToken.None);
+    }
+}

--- a/TransactionProcessor.Mobile/Pages/Reports/ReportsPage.xaml.cs
+++ b/TransactionProcessor.Mobile/Pages/Reports/ReportsPage.xaml.cs
@@ -46,6 +46,7 @@ public partial class ReportsPage : NoBackWithoutLogoutPage
             "Daily Performance Summary" => "salesvalue.svg",
             "Sales Analysis" => "transactionsbutton.svg",
             "Balance Analysis" => "reportbutton.svg",
+            "Recent Activity and Receipt Report" => "reportbutton.svg",
             _ => "reportbutton.svg"
         };
 

--- a/TransactionProcessor.Mobile/UIServices/DialogService.cs
+++ b/TransactionProcessor.Mobile/UIServices/DialogService.cs
@@ -49,6 +49,20 @@ namespace TransactionProcessor.Mobile.UIServices
                                                                cancellationToken);
         }
 
+        public async Task ShowSuccessToast(String message,
+                                           Action? action = null,
+                                           String? actionButtonText = "OK",
+                                           TimeSpan? duration = null,
+                                           CancellationToken cancellationToken = default)
+        {
+            await Application.Current.MainPage.DisplaySnackbar(message,
+                                                               action,
+                                                               actionButtonText,
+                                                               duration,
+                                                               SnackBarOptionsHelper.GetSuccessSnackbarOptions,
+                                                               cancellationToken);
+        }
+
         public async Task ShowWarningToast(String message,
                                            Action? action = null,
                                            String? actionButtonText = "OK",

--- a/TransactionProcessor.Mobile/UIServices/ShellNavigationService.cs
+++ b/TransactionProcessor.Mobile/UIServices/ShellNavigationService.cs
@@ -194,6 +194,20 @@ public class ShellNavigationService : INavigationService
         await this.NavigateTo(nameof(TransactionMixPage));
     }
 
+    public async Task GoToRecentActivityReportPage()
+    {
+        await this.NavigateTo(nameof(RecentActivityReportPage));
+    }
+
+    public async Task GoToRecentActivityReceiptDetailPage(TransactionProcessor.Mobile.BusinessLogic.Models.RecentActivityReceiptItemModel item)
+    {
+        Dictionary<String, Object> d = new Dictionary<String, Object>() {
+                                                                            {nameof(TransactionProcessor.Mobile.BusinessLogic.Models.RecentActivityReceiptItemModel), item},
+                                                                        };
+
+        await this.NavigateTo(nameof(RecentActivityReceiptDetailPage), d);
+    }
+
     public async Task GoToTransactions() {
         await this.NavigateTo("///main/transactions");
     }

--- a/TransactionProcessor.Mobile/UIServices/SnackBarOptionsHelper.cs
+++ b/TransactionProcessor.Mobile/UIServices/SnackBarOptionsHelper.cs
@@ -19,6 +19,12 @@ public static class SnackBarOptionsHelper
                                 TextColor = Colors.White
                             };
 
+    public static SnackbarOptions GetSuccessSnackbarOptions =>
+        new SnackbarOptions {
+                                BackgroundColor = Color.FromArgb("#1E8E3E"),
+                                TextColor = Colors.White
+                            };
+
     public static SnackbarOptions GetWarningSnackbarOptions =>
         new SnackbarOptions {
                                 BackgroundColor = Colors.Orange,

--- a/docs/superpowers/plans/2026-07-07-recent-activity-and-receipt-report.md
+++ b/docs/superpowers/plans/2026-07-07-recent-activity-and-receipt-report.md
@@ -1,0 +1,172 @@
+# Recent Activity and Receipt Report Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated recent activity and receipt report flow with a separate page stack, a single-date filter, and hardcoded results that exercise the screen flow before the real API is wired in.
+
+**Architecture:** Add a report query and service seam that returns a mocked recent-activity payload for now, then build a new report page and a separate detail page that navigate through the existing Shell-based page stack. Keep the date input to a single `DateTime` throughout the flow so the UI, request, and mock data all match the eventual API contract.
+
+**Tech Stack:** .NET MAUI, Shell navigation, MediatR, SimpleResults, CommunityToolkit.Mvvm, xUnit, Moq, Shouldly, MAUI UI tests.
+
+## Global Constraints
+
+- The report must use a single date, not a date range.
+- The current implementation must return hardcoded/mock data instead of calling the API.
+- The report must open as a separate page from the report landing page.
+- The detail view must be a separate page reachable from the report list.
+- Follow the existing report page, Shell, and viewmodel patterns already used in the app.
+
+---
+
+### Task 1: Add the report data contract, query, handler, and mocked service result
+
+**Files:**
+- Create: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic\Models\RecentActivityReceiptReportModel.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic\Requests\ReportQueries.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic\RequestHandlers\ReportRequestHandler.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic\Services\ReportsService.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic.Tests\RequestHandlerTests\ReportRequestHandlerTests.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic.Tests\ServicesTests\ReportsServiceTests.cs`
+
+**Interfaces:**
+- Consumes: `IApplicationCache.GetMerchantDetails()`, `IReportsService`
+- Produces: `ReportQueries.GetRecentActivityReceiptReportQuery`, `IReportsService.GetRecentActivityReceiptReport(...)`, `RecentActivityReceiptReportModel.CreateMock(...)`
+
+- [ ] **Step 1: Write the failing test**
+
+Add one unit test that sends `new ReportQueries.GetRecentActivityReceiptReportQuery(new DateTime(2026, 7, 6), "TXN-10001")` through `ReportRequestHandler` and asserts the result contains a single-day payload with a matching reference and no date range fields.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj --filter FullyQualifiedName~ReportRequestHandlerTests`
+
+Expected: compile or assertion failure because the query, handler, and model do not exist yet.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add a new report model and mock factory such as:
+
+```csharp
+public sealed record RecentActivityReceiptReportModel
+{
+    public DateTime ReportDate { get; set; }
+    public IReadOnlyList<RecentActivityReceiptItemModel> Items { get; set; } = [];
+    public RecentActivityReceiptDetailModel? SelectedItem { get; set; }
+
+    public static RecentActivityReceiptReportModel CreateMock(DateTime reportDate, string? searchTerm)
+    {
+        return new RecentActivityReceiptReportModel
+        {
+            ReportDate = reportDate.Date,
+            Items =
+            [
+                new RecentActivityReceiptItemModel("TXN-10001", "Mobile Topup", "Safaricom", "Success", 100.00m, reportDate.Date.AddHours(9), true),
+                new RecentActivityReceiptItemModel("TXN-10002", "Bill Payment", "PataPawa", "Success", 250.00m, reportDate.Date.AddHours(10), true)
+            ],
+            SelectedItem = new RecentActivityReceiptDetailModel("TXN-10001", "Mobile Topup", "Custom", "Safaricom", "Success", 100.00m, reportDate.Date.AddHours(9), "RCPT-10001")
+        };
+    }
+}
+```
+
+Implement the query, handler, and service method so they pass the single date through and return the mock factory result.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj --filter FullyQualifiedName~ReportRequestHandlerTests`
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TransactionProcessor.Mobile.BusinessLogic/Models/RecentActivityReceiptReportModel.cs TransactionProcessor.Mobile.BusinessLogic/Requests/ReportQueries.cs TransactionProcessor.Mobile.BusinessLogic/RequestHandlers/ReportRequestHandler.cs TransactionProcessor.Mobile.BusinessLogic/Services/ReportsService.cs TransactionProcessor.Mobile.BusinessLogic.Tests/RequestHandlerTests/ReportRequestHandlerTests.cs TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/ReportsServiceTests.cs
+git commit -m "feat: add recent activity report contract"
+```
+
+### Task 2: Build the report pages and navigation flow
+
+**Files:**
+- Create: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic\ViewModels\Reports\RecentActivityReportPageViewModel.cs`
+- Create: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic\ViewModels\Reports\RecentActivityReceiptDetailPageViewModel.cs`
+- Create: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile\Pages\Reports\RecentActivityReportPage.xaml`
+- Create: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile\Pages\Reports\RecentActivityReportPage.xaml.cs`
+- Create: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile\Pages\Reports\RecentActivityReceiptDetailPage.xaml`
+- Create: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile\Pages\Reports\RecentActivityReceiptDetailPage.xaml.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic\UIServices\INavigationService.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile\UIServices\ShellNavigationService.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile\Extensions\MauiAppBuilderExtensions.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile\AppShell.xaml`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.BusinessLogic\ViewModels\Reports\ReportsPageViewModel.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile\Pages\Reports\ReportsPage.xaml.cs`
+
+**Interfaces:**
+- Consumes: `ReportQueries.GetRecentActivityReceiptReportQuery`, `INavigationParameterService`
+- Produces: `GoToRecentActivityReportPage()`, `GoToRecentActivityReceiptDetailPage(...)`, `RecentActivityReportPageViewModel`, `RecentActivityReceiptDetailPageViewModel`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a viewmodel test that selects the new report option and verifies navigation to the report page, plus a second test that uses a single date and verifies the query carries only that one date.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj --filter FullyQualifiedName~RecentActivity`
+
+Expected: compile failure because the new viewmodels, navigation methods, and page routes do not exist yet.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create a report landing option for `Recent Activity and Receipt Report`, a report page with one date picker, a search box, a results list, and a tap action that opens a separate detail page. The detail page should read the selected item through `INavigationParameterService` and show the receipt/reference fields in a compact layout.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj --filter FullyQualifiedName~RecentActivity`
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/RecentActivityReportPageViewModel.cs TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/RecentActivityReceiptDetailPageViewModel.cs TransactionProcessor.Mobile/Pages/Reports/RecentActivityReportPage.xaml TransactionProcessor.Mobile/Pages/Reports/RecentActivityReportPage.xaml.cs TransactionProcessor.Mobile/Pages/Reports/RecentActivityReceiptDetailPage.xaml TransactionProcessor.Mobile/Pages/Reports/RecentActivityReceiptDetailPage.xaml.cs TransactionProcessor.Mobile.BusinessLogic/UIServices/INavigationService.cs TransactionProcessor.Mobile/UIServices/ShellNavigationService.cs TransactionProcessor.Mobile/Extensions/MauiAppBuilderExtensions.cs TransactionProcessor.Mobile/AppShell.xaml TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/ReportsPageViewModel.cs TransactionProcessor.Mobile/Pages/Reports/ReportsPage.xaml.cs
+git commit -m "feat: add recent activity report navigation"
+```
+
+### Task 3: Add UI test coverage for the new flow
+
+**Files:**
+- Create: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.UITests\Pages\RecentActivityReportPage.cs`
+- Create: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.UITests\Pages\RecentActivityReceiptDetailPage.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.UITests\Steps\ReportsSteps.cs`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.UITests\Features\Reporting.feature`
+- Modify: `D:\Projects\TransactionProcessing\TransactionMobile\TransactionProcessor.Mobile.UITests\Features\Reporting.feature.cs`
+
+**Interfaces:**
+- Consumes: the new report page automation ids and detail page automation ids
+- Produces: a navigation test that reaches the report page, applies a single date, opens a result, and lands on the detail page
+
+- [ ] **Step 1: Write the failing test**
+
+Add a UI test scenario that navigates from Reports to the new report, selects a date, triggers search, and opens the first result.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test TransactionProcessor.Mobile.UITests/TransactionProcessor.Mobile.UITests.csproj --filter FullyQualifiedName~Reporting`
+
+Expected: failure because the new pages and automation ids are not yet wired into the UI test layer.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add page objects and step definitions for the new pages, then wire the feature file to the new scenario and automation ids.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test TransactionProcessor.Mobile.UITests/TransactionProcessor.Mobile.UITests.csproj --filter FullyQualifiedName~Reporting`
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TransactionProcessor.Mobile.UITests/Pages/RecentActivityReportPage.cs TransactionProcessor.Mobile.UITests/Pages/RecentActivityReceiptDetailPage.cs TransactionProcessor.Mobile.UITests/Steps/ReportsSteps.cs TransactionProcessor.Mobile.UITests/Features/Reporting.feature TransactionProcessor.Mobile.UITests/Features/Reporting.feature.cs
+git commit -m "test: cover recent activity report flow"
+```


### PR DESCRIPTION
Implements end-to-end flow for Recent Activity and Receipt Report, including data models, MediatR query/handler, service seam, ViewModels, XAML pages, navigation, and both unit and UI tests. Supports single-date filtering, search, paging, and receipt resend with mock data. Updates reports menu, navigation, and dialog service for new functionality.

closes #641 