### PR TITLE
Cache merchant details after login and reuse in account

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/LoginPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/LoginPageViewModelTests.cs
@@ -67,12 +67,14 @@ public class LoginPageViewModelTests
         this.Mediator.Setup(m => m.Send(It.IsAny<LogonCommands.GetTokenCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.AccessToken));
         this.Mediator.Setup(m => m.Send(It.IsAny<TransactionCommands.PerformLogonCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.PerformLogonResponseModel));
         this.Mediator.Setup(m => m.Send(It.IsAny<MerchantQueries.GetContractProductsQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
-        
+        this.Mediator.Setup(m => m.Send(It.IsAny<MerchantQueries.GetMerchantDetailsQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantDetailsModel));
+
         this.ViewModel.LogonCommand.Execute(null);
         
         this.Mediator.Verify(x => x.Send(It.IsAny<LogonCommands.GetTokenCommand>(), It.IsAny<CancellationToken>()), Times.Once);
         this.Mediator.Verify(x => x.Send(It.IsAny<TransactionCommands.PerformLogonCommand>(), It.IsAny<CancellationToken>()), Times.Once);
         this.Mediator.Verify(x => x.Send(It.IsAny<MerchantQueries.GetContractProductsQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        this.Mediator.Verify(x => x.Send(It.IsAny<MerchantQueries.GetMerchantDetailsQuery>(), It.IsAny<CancellationToken>()), Times.Once);
         this.NavigationService.Verify(n => n.GoToHome(), Times.Once);
     }
 
@@ -86,6 +88,8 @@ public class LoginPageViewModelTests
         this.Mediator.Setup(m => m.Send(It.IsAny<LogonCommands.GetTokenCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.AccessToken));
         this.Mediator.Setup(m => m.Send(It.IsAny<TransactionCommands.PerformLogonCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.PerformLogonResponseModel));
         this.Mediator.Setup(m => m.Send(It.IsAny<MerchantQueries.GetContractProductsQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
+        this.Mediator.Setup(m => m.Send(It.IsAny<MerchantQueries.GetMerchantDetailsQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantDetailsModel));
+
         this.ViewModel.ConfigHostUrl = configUrl;
 
         this.ViewModel.LogonCommand.Execute(null);
@@ -93,6 +97,7 @@ public class LoginPageViewModelTests
         this.Mediator.Verify(x => x.Send(It.IsAny<LogonCommands.GetTokenCommand>(), It.IsAny<CancellationToken>()), Times.Once);
         this.Mediator.Verify(x => x.Send(It.IsAny<TransactionCommands.PerformLogonCommand>(), It.IsAny<CancellationToken>()), Times.Once);
         this.Mediator.Verify(x => x.Send(It.IsAny<MerchantQueries.GetContractProductsQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        this.Mediator.Verify(x => x.Send(It.IsAny<MerchantQueries.GetMerchantDetailsQuery>(), It.IsAny<CancellationToken>()), Times.Once);
         this.NavigationService.Verify(n => n.GoToHome(), Times.Once);
         if (String.IsNullOrEmpty(configUrl) == false){
             this.ApplicationCache.Verify(v => v.SetConfigHostUrl(It.IsAny<String>(), It.IsAny<MemoryCacheEntryOptions>()), Times.Once);
@@ -147,6 +152,9 @@ public class LoginPageViewModelTests
         this.Mediator.Setup(m => m.Send(It.IsAny<TransactionCommands.PerformLogonCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.PerformLogonResponseModel));
         this.Mediator.Setup(m => m.Send(It.IsAny<MerchantQueries.GetContractProductsQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.ContractProductList));
         this.Mediator.Setup(m => m.Send(It.IsAny<MerchantQueries.GetMerchantBalanceQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantBalance));
+        this.Mediator.Setup(m => m.Send(It.IsAny<MerchantQueries.GetMerchantDetailsQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantDetailsModel));
+        this.Mediator.Setup(m => m.Send(It.IsAny<MerchantQueries.GetMerchantDetailsQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.MerchantDetailsModel));
+
         this.ApplicationInfoService.Setup(a => a.VersionString).Returns(TestData.ApplicationVersion);
         this.ApplicationInfoService.Setup(a => a.PackageName).Returns("com.transactionprocessor.mobile");
         this.DeviceService.Setup(d => d.GetPlatform()).Returns("Android");

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/LoginPageViewModel.cs
@@ -123,6 +123,12 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels
             TransactionCommands.PerformLogonCommand command = new(DateTime.Now);
             return await this.Mediator.Send(command);
         }
+        
+        private async Task<Result<MerchantDetailsModel>> GetMerchantDetails()
+        {
+            MerchantQueries.GetMerchantDetailsQuery query = new MerchantQueries.GetMerchantDetailsQuery();
+            return  await this.Mediator.Send(query);
+        }
 
         private async Task<Result<List<ContractProductModel>>> GetMerchantContractProducts() {
             // Get Contracts
@@ -245,9 +251,13 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels
                 await this.WriteTimingTrace(sw, "After PerformLogonTransaction");
                 Result<List<ContractProductModel>> getMerchantContractProductsResult = await this.GetMerchantContractProducts();
                 this.HandleResult(getMerchantContractProductsResult);
-
                 await this.WriteTimingTrace(sw, "After GetMerchantContractProducts");
-                
+
+                Result<MerchantDetailsModel> getMerchantDetailsResult = await this.GetMerchantDetails();
+                this.HandleResult(getMerchantDetailsResult);
+                await this.WriteTimingTrace(sw, "After GetMerchantDetails");
+
+                this.ApplicationCache.SetMerchantDetails(getMerchantDetailsResult.Data);
                 this.ApplicationCache.SetIsLoggedIn(true);
                 
                 this.BalanceRefresher.StartRefreshing();

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/MyAccount/MyAccountPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/MyAccount/MyAccountPageViewModel.cs
@@ -73,16 +73,24 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.MyAccount
                 new() { Title = "Logout" }
             ];
 
-            MerchantQueries.GetMerchantDetailsQuery query = new MerchantQueries.GetMerchantDetailsQuery();
+            MerchantDetailsModel merchant = this.ApplicationCache.GetMerchantDetails();
+            if (merchant == null)
+            {
+                MerchantQueries.GetMerchantDetailsQuery query = new();
 
-            Result<MerchantDetailsModel> merchantDetailsResult = await this.Mediator.Send(query, cancellationToken);
-            if (merchantDetailsResult.IsFailed) {
-                await this.DialogService.ShowWarningToast("Unable to load merchant details. Please try again later.", cancellationToken: cancellationToken);
-                return;
+                Result<MerchantDetailsModel> merchantDetailsResult = await this.Mediator.Send(query, cancellationToken);
+                if (merchantDetailsResult.IsFailed)
+                {
+                    await this.DialogService.ShowWarningToast("Unable to load merchant details. Please try again later.", cancellationToken: cancellationToken);
+                    return;
+                }
+
+                this.MerchantName = merchantDetailsResult.Data.MerchantName;
             }
-
-            this.MerchantName = merchantDetailsResult.Data.MerchantName;
-
+            else {
+                this.MerchantName = merchant.MerchantName;
+            }
+            
             this.LastLogin = this.ApplicationCache.GetLastLoginDate();
             this.IsDarkThemeEnabled = await this.ApplicationThemeService.GetDarkThemeEnabled();
         }


### PR DESCRIPTION
Added GetMerchantDetails to LoginPageViewModel and updated the login flow to fetch and cache merchant details. Modified MyAccountPageViewModel to use cached merchant details when available, reducing redundant queries and improving efficiency.

closes #651 