### PR TITLE
Fix Windows support upload navigation

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Support/SupportPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Support/SupportPageViewModelTests.cs
@@ -57,7 +57,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ViewModelTests.Support
             await this.ViewModel.UploadLogsCommand.ExecuteAsync(null);
 
             this.Mediator.Verify(m => m.Send(It.IsAny<SupportCommands.UploadLogsCommand>(),It.IsAny<CancellationToken>()),Times.Once);
-            this.DialogService.Verify(d => d.ShowInformationToast("Logs have been uploaded successfully."), Times.Once);
+            this.DialogService.Verify(d => d.ShowUploadLogsCompleteNotice(), Times.Once);
             this.NavigationService.Verify(n => n.GoBack(), Times.Never);
         }
 

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Support/SupportPageViewModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ViewModelTests/Support/SupportPageViewModelTests.cs
@@ -51,12 +51,14 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ViewModelTests.Support
         }
 
         [Fact]
-        public void SupportPageViewModel_UploadLogsCommand_Execute_IsExecuted()
+        public async Task SupportPageViewModel_UploadLogsCommand_Execute_IsExecuted()
         {
             this.Mediator.Setup(m => m.Send(It.IsAny<SupportCommands.UploadLogsCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
-            this.ViewModel.UploadLogsCommand.Execute(null);
+            await this.ViewModel.UploadLogsCommand.ExecuteAsync(null);
 
             this.Mediator.Verify(m => m.Send(It.IsAny<SupportCommands.UploadLogsCommand>(),It.IsAny<CancellationToken>()),Times.Once);
+            this.DialogService.Verify(d => d.ShowInformationToast("Logs have been uploaded successfully."), Times.Once);
+            this.NavigationService.Verify(n => n.GoBack(), Times.Never);
         }
 
         [Fact]

--- a/TransactionProcessor.Mobile.BusinessLogic/UIServices/IDialogService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/UIServices/IDialogService.cs
@@ -26,6 +26,8 @@ public interface IDialogService
                               TimeSpan? duration = null,
                               CancellationToken cancellationToken = default);
 
+    Task ShowUploadLogsCompleteNotice();
+
     Task ShowSuccessToast(String message,
                           Action? action = null,
                           String? actionButtonText = "OK",

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Support/SupportPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Support/SupportPageViewModel.cs
@@ -74,7 +74,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.Support
             var result = await this.Mediator.Send(command, CancellationToken.None);
 
             if (result.IsSuccess) {
-                await this.DialogService.ShowInformationToast("Logs have been uploaded successfully.");
+                await this.DialogService.ShowUploadLogsCompleteNotice();
             } else {
                 await this.DialogService.ShowWarningToast("Failed to upload logs.");
             }

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Support/SupportPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Support/SupportPageViewModel.cs
@@ -75,7 +75,6 @@ namespace TransactionProcessor.Mobile.BusinessLogic.ViewModels.Support
 
             if (result.IsSuccess) {
                 await this.DialogService.ShowInformationToast("Logs have been uploaded successfully.");
-                await this.NavigationService.GoBack();
             } else {
                 await this.DialogService.ShowWarningToast("Failed to upload logs.");
             }

--- a/TransactionProcessor.Mobile.UITests/Steps/ToolbarSteps.cs
+++ b/TransactionProcessor.Mobile.UITests/Steps/ToolbarSteps.cs
@@ -58,12 +58,6 @@ public class SupportSteps{
     [When(@"I tap on the Upload Logs Button")]
     public async Task WhenITapOnTheUploadLogsButton()
     {
-        if (TransactionProcessor.Mobile.UITests.Drivers.AppiumDriverWrapper.MobileTestPlatform == TransactionProcessor.Mobile.UITests.Drivers.MobileTestPlatform.Windows)
-        {
-            Console.WriteLine("Skipping Upload Logs interaction on Windows until the application navigation crash is fixed.");
-            return;
-        }
-
         await this.supportPage.ClickUploadLogsButton();
     }
 

--- a/TransactionProcessor.Mobile/UIServices/DialogService.cs
+++ b/TransactionProcessor.Mobile/UIServices/DialogService.cs
@@ -45,8 +45,27 @@ namespace TransactionProcessor.Mobile.UIServices
                                                                action,
                                                                actionButtonText,
                                                                duration,
-                                                               SnackBarOptionsHelper.GetInfoSnackbarOptions,
-                                                               cancellationToken);
+                                                                SnackBarOptionsHelper.GetInfoSnackbarOptions,
+                                                                cancellationToken);
+        }
+
+        public async Task ShowUploadLogsCompleteNotice()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                await Application.Current.MainPage.DisplayAlert(
+                    "Logs uploaded",
+                    "Logs have been uploaded successfully.",
+                    "OK");
+                return;
+            }
+
+            await Application.Current.MainPage.DisplaySnackbar(
+                "Logs have been uploaded successfully.",
+                null,
+                "OK",
+                null,
+                SnackBarOptionsHelper.GetSuccessSnackbarOptions);
         }
 
         public async Task ShowSuccessToast(String message,


### PR DESCRIPTION
Remove the Support upload back navigation that could close the Windows app; re-enable the Windows upload step; verification: dotnet test TransactionProcessor.Mobile.BusinessLogic.Tests/TransactionProcessor.Mobile.BusinessLogic.Tests.csproj --filter FullyQualifiedName~SupportPageViewModelTests; dotnet build TransactionProcessor.Mobile.UITests/TransactionProcessor.Mobile.UITests.csproj