### PR TITLE
Fix Codacy warnings in mobile transaction and reports code

### DIFF
--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/Models/RecentActivityReceiptReportModelTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/Models/RecentActivityReceiptReportModelTests.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using Shouldly;
+using TransactionProcessor.Mobile.BusinessLogic.Models;
+
+namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ReportModelTests;
+
+public class RecentActivityReceiptReportModelTests
+{
+    [Fact]
+    public void RecentActivityReceiptReportModel_DefinesSharedSuccessStatusConstant()
+    {
+        FieldInfo? field = typeof(RecentActivityReceiptReportModel).GetField("SuccessStatus", BindingFlags.NonPublic | BindingFlags.Static);
+
+        field.ShouldNotBeNull();
+        field!.IsLiteral.ShouldBeTrue();
+        field.GetRawConstantValue().ShouldBe("Success");
+    }
+}

--- a/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/TransactionServiceTests.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic.Tests/ServicesTests/TransactionServiceTests.cs
@@ -4,6 +4,7 @@ using Shouldly;
 using SimpleResults;
 using System.Net;
 using System.Text;
+using System.Reflection;
 using TransactionProcessor.Mobile.BusinessLogic.Logging;
 using TransactionProcessor.Mobile.BusinessLogic.Models;
 using TransactionProcessor.Mobile.BusinessLogic.Serialisation;
@@ -30,6 +31,16 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Tests.ServicesTests
         Object Deserialise(String arg, Type type)
         {
             return StringSerialiser.DeserializeObject<Object>(arg, type, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+        }
+
+        [Fact]
+        public void TransactionService_DefinesSharedSaleTransactionsRouteConstant()
+        {
+            FieldInfo? routeField = typeof(TransactionService).GetField("SaleTransactionRoute", BindingFlags.NonPublic | BindingFlags.Static);
+
+            routeField.ShouldNotBeNull();
+            routeField!.IsLiteral.ShouldBeTrue();
+            routeField.GetRawConstantValue().ShouldBe("api/saletransactions");
         }
 
         void ArrangeThrowingSaleTransactionHandler()

--- a/TransactionProcessor.Mobile.BusinessLogic/Models/RecentActivityReceiptReportModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Models/RecentActivityReceiptReportModel.cs
@@ -2,6 +2,8 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Models;
 
 public sealed record RecentActivityReceiptReportModel
 {
+    private const string SuccessStatus = "Success";
+
     public DateTime ReportDate { get; set; }
 
     public string? SearchText { get; set; }
@@ -25,13 +27,13 @@ public sealed record RecentActivityReceiptReportModel
     {
         List<RecentActivityReceiptItemModel> items =
         [
-            new("TXN-10001", "Mobile Topup", "Custom", "Safaricom", "Success", 100.00m, reportDate.Date.AddHours(9).AddMinutes(30), "RCPT-10001"),
-            new("TXN-10002", "Bill Payment", "Bill Pay (Post)", "PataPawa PostPay", "Success", 250.00m, reportDate.Date.AddHours(10).AddMinutes(15), "RCPT-10002"),
+            new("TXN-10001", "Mobile Topup", "Custom", "Safaricom", SuccessStatus, 100.00m, reportDate.Date.AddHours(9).AddMinutes(30), "RCPT-10001"),
+            new("TXN-10002", "Bill Payment", "Bill Pay (Post)", "PataPawa PostPay", SuccessStatus, 250.00m, reportDate.Date.AddHours(10).AddMinutes(15), "RCPT-10002"),
             new("TXN-10003", "Voucher Issue", "10 KES", "Voucher", "Failed", 0.00m, reportDate.Date.AddHours(11).AddMinutes(5), "RCPT-10003"),
-            new("TXN-10004", "Mobile Topup", "Airtime", "Airtel", "Success", 50.00m, reportDate.Date.AddHours(12).AddMinutes(20), "RCPT-10004"),
+            new("TXN-10004", "Mobile Topup", "Airtime", "Airtel", SuccessStatus, 50.00m, reportDate.Date.AddHours(12).AddMinutes(20), "RCPT-10004"),
             new("TXN-10005", "Bill Payment", "Prepaid Power", "KPLC", "Failed", 75.00m, reportDate.Date.AddHours(13).AddMinutes(5), "RCPT-10005"),
-            new("TXN-10006", "Voucher Issue", "20 KES", "Voucher", "Success", 20.00m, reportDate.Date.AddHours(14).AddMinutes(10), "RCPT-10006"),
-            new("TXN-10007", "Mobile Topup", "Custom", "Safaricom", "Success", 500.00m, reportDate.Date.AddHours(15).AddMinutes(55), "RCPT-10007"),
+            new("TXN-10006", "Voucher Issue", "20 KES", "Voucher", SuccessStatus, 20.00m, reportDate.Date.AddHours(14).AddMinutes(10), "RCPT-10006"),
+            new("TXN-10007", "Mobile Topup", "Custom", "Safaricom", SuccessStatus, 500.00m, reportDate.Date.AddHours(15).AddMinutes(55), "RCPT-10007"),
         ];
 
         if (string.IsNullOrWhiteSpace(searchText) == false)

--- a/TransactionProcessor.Mobile.BusinessLogic/Services/TransactionService.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/Services/TransactionService.cs
@@ -33,6 +33,8 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
     {
         #region Fields
 
+        private const string SaleTransactionRoute = "api/saletransactions";
+
         private readonly IApplicationCache ApplicationCache;
 
         private readonly Func<String, String> BaseAddressResolver;
@@ -57,7 +59,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
                                                                                                           CancellationToken cancellationToken) {
             Logger.LogInformation("About to perform bill payment get account transaction");
 
-            Result<SaleTransactionResponseMessage> result = await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(), "api/saletransactions", cancellationToken);
+            Result<SaleTransactionResponseMessage> result = await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(), SaleTransactionRoute, cancellationToken);
 
             if (result.IsSuccess == false) {
                 Logger.LogWarning("Error performing bill payment - get account transaction");
@@ -75,7 +77,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
                                                                                                             CancellationToken cancellationToken) {
             Logger.LogInformation("About to perform bill payment make payment transaction");
             
-            Result<SaleTransactionResponseMessage> result = await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(),"api/saletransactions", cancellationToken);
+            Result<SaleTransactionResponseMessage> result = await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(), SaleTransactionRoute, cancellationToken);
 
             if (result.IsSuccess == false) {
                 Logger.LogWarning("Error performing bill payment - make payment transaction");
@@ -92,7 +94,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
         public async Task<Result<PerformBillPaymentGetMeterResponseModel>> PerformBillPaymentGetMeter(PerformBillPaymentGetMeterModel model, CancellationToken cancellationToken){
             Logger.LogInformation("About to perform bill payment get meter transaction");
 
-            Result<SaleTransactionResponseMessage> result = await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(), "api/saletransactions", cancellationToken);
+            Result<SaleTransactionResponseMessage> result = await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(), SaleTransactionRoute, cancellationToken);
 
             if (result.IsSuccess == false) {
                 Logger.LogWarning("Error performing bill payment - get meter transaction");
@@ -130,7 +132,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
             Logger.LogInformation("About to perform mobile top-up transaction");
 
             Result<SaleTransactionResponseMessage> result =
-                await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(), "api/saletransactions", cancellationToken);
+                await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(), SaleTransactionRoute, cancellationToken);
 
             if (result.IsSuccess == false) {
                 Logger.LogWarning("Error performing Mobile top-up transaction");
@@ -169,7 +171,7 @@ namespace TransactionProcessor.Mobile.BusinessLogic.Services
                                                                                       CancellationToken cancellationToken) {
             Logger.LogInformation("About to perform voucher transaction");
 
-            Result<SaleTransactionResponseMessage> result = await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(), "api/saletransactions", cancellationToken);
+            Result<SaleTransactionResponseMessage> result = await this.SendTransactionRequest<SaleTransactionRequestMessage, SaleTransactionResponseMessage>(model.ToSaleTransactionRequest(), SaleTransactionRoute, cancellationToken);
             
             if (result.IsSuccess == false)
             {

--- a/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/RecentActivityReceiptDetailPageViewModel.cs
+++ b/TransactionProcessor.Mobile.BusinessLogic/ViewModels/Reports/RecentActivityReceiptDetailPageViewModel.cs
@@ -143,9 +143,9 @@ public sealed partial class RecentActivityReceiptDetailPageViewModel : ExtendedB
         await base.Initialise(cancellationToken);
 
         IDictionary<string, object> parameters = this.NavigationParameterService.GetParameters();
-        if (parameters.TryGetValue(nameof(RecentActivityReceiptItemModel), out object? item) && item is RecentActivityReceiptItemModel selectedItem)
+        if (parameters.TryGetValue(nameof(RecentActivityReceiptItemModel), out object? item) && item is RecentActivityReceiptItemModel receiptItem)
         {
-            this.SelectedItem = selectedItem;
+            this.SelectedItem = receiptItem;
         }
     }
 }


### PR DESCRIPTION
Summary:
- Centralize the shared sale transaction route constant in TransactionService
- Convert RecentActivityReceiptReportModel success labels to a shared constant
- Rename the shadowing selectedItem local in RecentActivityReceiptDetailPageViewModel

Verification:
- dotnet test TransactionProcessor.Mobile.BusinessLogic.Tests --filter "FullyQualifiedName~TransactionServiceTests" -v minimal
- dotnet test TransactionProcessor.Mobile.BusinessLogic.Tests --filter "FullyQualifiedName~RecentActivityReceiptReportModel_DefinesSharedSuccessStatusConstant" -v minimal
- dotnet test TransactionProcessor.Mobile.BusinessLogic.Tests --filter "FullyQualifiedName~RecentActivityReceiptDetailPageViewModelTests" -v minimal
