### PR TITLE
Fix MauiProgram container warning

### DIFF
--- a/TransactionProcessor.Mobile/MauiProgram.cs
+++ b/TransactionProcessor.Mobile/MauiProgram.cs
@@ -16,7 +16,7 @@ namespace TransactionProcessor.Mobile
 {
     public static class MauiProgram
     {
-        public static MauiApp Container;
+        public static MauiApp Container { get; private set; } = default!;
         public static MauiApp CreateMauiApp()
         {
             var builder = MauiApp.CreateBuilder();


### PR DESCRIPTION
## Summary\n- Change MauiProgram.Container from a mutable static field to a property with a private setter.\n- Keeps the current startup/service-locator pattern intact while satisfying the analyzer rule.\n\n## Verification\n- dotnet build TransactionProcessor.Mobile/TransactionProcessor.Mobile.csproj succeeded earlier in this session.\n- dotnet test TransactionProcessor.Mobile.sln reached the UI test project but failed in this environment because UITEST_ANDROID_APP_PATH is not set. CI should provide the required test environment.